### PR TITLE
Add rustfmt config and format all files

### DIFF
--- a/peppi/rustfmt.toml
+++ b/peppi/rustfmt.toml
@@ -1,0 +1,2 @@
+hard_tabs = true
+tab_spaces = 4

--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -16,9 +16,8 @@ pub struct SerializationConfig {
 // TODO: replace with `serde_state`?
 /// Global singleton, a hack to smuggle config into serializers.
 /// You probably don't care about this unless you're serializing with Serde.
-pub static mut SERIALIZATION_CONFIG: SerializationConfig = SerializationConfig {
-	enum_names: false,
-};
+pub static mut SERIALIZATION_CONFIG: SerializationConfig =
+	SerializationConfig { enum_names: false };
 
 pub(crate) mod ubjson {
 	pub(crate) mod de;
@@ -26,8 +25,12 @@ pub(crate) mod ubjson {
 }
 
 pub mod model {
-	#[macro_use] #[doc(hidden)] pub(crate) mod pseudo_bitmask;
-	#[macro_use] #[doc(hidden)] pub(crate) mod pseudo_enum;
+	#[macro_use]
+	#[doc(hidden)]
+	pub(crate) mod pseudo_bitmask;
+	#[macro_use]
+	#[doc(hidden)]
+	pub(crate) mod pseudo_enum;
 
 	pub mod buttons;
 	pub mod frame;
@@ -55,8 +58,7 @@ pub mod serde {
 }
 
 use std::{
-	error,
-	fmt,
+	error, fmt,
 	io::{self, Read},
 };
 
@@ -100,21 +102,32 @@ impl<R: Read> Read for TrackingReader<R> {
 }
 
 /// Parse a Slippi replay from `r`, passing events to the callbacks in `handlers` as they occur.
-pub fn parse<R: Read, H: serde::de::Handlers>(r: &mut R, handlers: &mut H, opts: Option<serde::de::Opts>) -> std::result::Result<(), ParseError> {
-	let mut r = TrackingReader {
-		pos: 0,
-		reader: r,
-	};
-	serde::de::deserialize(&mut r, handlers, opts)
-		.map_err(|e| ParseError { error: e, pos: Some(r.pos) })
+pub fn parse<R: Read, H: serde::de::Handlers>(
+	r: &mut R,
+	handlers: &mut H,
+	opts: Option<serde::de::Opts>,
+) -> std::result::Result<(), ParseError> {
+	let mut r = TrackingReader { pos: 0, reader: r };
+	serde::de::deserialize(&mut r, handlers, opts).map_err(|e| ParseError {
+		error: e,
+		pos: Some(r.pos),
+	})
 }
 
 /// Parse a Slippi replay from `r`, returning a `game::Game` object.
-pub fn game<R: Read>(r: &mut R, parse_opts: Option<serde::de::Opts>, collect_opts: Option<serde::collect::Opts>) -> Result<model::game::Game, ParseError> {
+pub fn game<R: Read>(
+	r: &mut R,
+	parse_opts: Option<serde::de::Opts>,
+	collect_opts: Option<serde::collect::Opts>,
+) -> Result<model::game::Game, ParseError> {
 	let mut game_parser = serde::collect::Collector {
 		opts: collect_opts.unwrap_or_default(),
 		..Default::default()
 	};
-	parse(r, &mut game_parser, parse_opts)
-		.and_then(|_| game_parser.into_game().map_err(|e| ParseError { error: e, pos: None }))
+	parse(r, &mut game_parser, parse_opts).and_then(|_| {
+		game_parser.into_game().map_err(|e| ParseError {
+			error: e,
+			pos: None,
+		})
+	})
 }

--- a/peppi/src/model/enums/action_state.rs
+++ b/peppi/src/model/enums/action_state.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use super::character::Internal;
+use std::fmt;
 
 const MAX_COMMON_STATE: u16 = 340;
 

--- a/peppi/src/model/frame.rs
+++ b/peppi/src/model/frame.rs
@@ -1,16 +1,11 @@
-use serde::{
-	Serialize,
-	ser::SerializeStruct,
-};
+use serde::{ser::SerializeStruct, Serialize};
 
-use crate::{
-	model::{
-		buttons,
-		enums::{action_state, attack, character, ground},
-		item,
-		primitives::{Direction, Port, Position, Velocity},
-		triggers,
-	},
+use crate::model::{
+	buttons,
+	enums::{action_state, attack, character, ground},
+	item,
+	primitives::{Direction, Port, Position, Velocity},
+	triggers,
 };
 
 use peppi_derive::Arrow;
@@ -57,14 +52,16 @@ pub struct Start {
 	/// Scene frame counter. Starts at 0 when game starts. Continues to count frames
 	/// even if the game is paused.
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "3.10")] pub scene_frame_counter: Option<u32>,
+	#[slippi(version = "3.10")]
+	pub scene_frame_counter: Option<u32>,
 }
 
 /// End-of-frame data.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Arrow)]
 pub struct End {
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "3.7")] pub latest_finalized_frame: Option<i32>,
+	#[slippi(version = "3.7")]
+	pub latest_finalized_frame: Option<i32>,
 }
 
 /// The game tracks two different "velocities" per character, autogenous (self-induced)
@@ -78,7 +75,8 @@ pub struct Velocities {
 	pub knockback: Velocity,
 	/// For ergonomics we merge air+ground autogenous velocities into `.autogenous`, based on
 	/// the character's `airborne` state. But we also keep the original values for round-tripping.
-	#[serde(skip)] #[doc(hidden)]
+	#[serde(skip)]
+	#[doc(hidden)]
 	pub autogenous_x: AutogenousXVelocity,
 }
 
@@ -102,9 +100,11 @@ pub struct Pre {
 	pub buttons: Buttons,
 	pub state: action_state::State,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "1.2")] pub raw_analog_x: Option<u8>,
+	#[slippi(version = "1.2")]
+	pub raw_analog_x: Option<u8>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "1.4")] pub damage: Option<f32>,
+	#[slippi(version = "1.4")]
+	pub damage: Option<f32>,
 }
 
 /// Post-frame update data, for computing stats etc.
@@ -128,33 +128,44 @@ pub struct Post {
 	/// stocks remaining
 	pub stocks: u8,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "0.2")] pub state_age: Option<f32>,
+	#[slippi(version = "0.2")]
+	pub state_age: Option<f32>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "2.0")] pub flags: Option<StateFlags>,
+	#[slippi(version = "2.0")]
+	pub flags: Option<StateFlags>,
 	/// used for multiple things, including hitstun frames remaining
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "2.0")] pub misc_as: Option<f32>,
+	#[slippi(version = "2.0")]
+	pub misc_as: Option<f32>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "2.0")] pub airborne: Option<bool>,
+	#[slippi(version = "2.0")]
+	pub airborne: Option<bool>,
 	/// ground the character is standing on, if any
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "2.0")] pub ground: Option<ground::Ground>,
+	#[slippi(version = "2.0")]
+	pub ground: Option<ground::Ground>,
 	/// jumps remaining
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "2.0")] pub jumps: Option<u8>,
+	#[slippi(version = "2.0")]
+	pub jumps: Option<u8>,
 	/// true = successful L-Cancel
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "2.0")] pub l_cancel: Option<Option<bool>>,
+	#[slippi(version = "2.0")]
+	pub l_cancel: Option<Option<bool>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "2.1")] pub hurtbox_state: Option<HurtboxState>,
+	#[slippi(version = "2.1")]
+	pub hurtbox_state: Option<HurtboxState>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "3.5")] pub velocities: Option<Velocities>,
+	#[slippi(version = "3.5")]
+	pub velocities: Option<Velocities>,
 	/// hitlag remaining
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "3.8")] pub hitlag: Option<f32>,
+	#[slippi(version = "3.8")]
+	pub hitlag: Option<f32>,
 	/// animation the character is in (for Wait: 2 = Wait1, 3 = Wait2, 4 = Wait3)
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "3.11")] pub animation_index: Option<u32>,
+	#[slippi(version = "3.11")]
+	pub animation_index: Option<u32>,
 }
 
 /// Frame data for a single character. Includes both pre-frame and post-frame data.
@@ -189,14 +200,20 @@ pub struct Frame<const N: usize> {
 	pub index: i32,
 	/// Frame data for each port. The player with the lowest port is always at index 0.
 	pub ports: [PortData; N],
-	#[slippi(version = "2.2")] pub start: Option<Start>,
-	#[slippi(version = "3.0")] pub end: Option<End>,
-	#[slippi(version = "3.0")] pub items: Option<Vec<item::Item>>,
+	#[slippi(version = "2.2")]
+	pub start: Option<Start>,
+	#[slippi(version = "3.0")]
+	pub end: Option<End>,
+	#[slippi(version = "3.0")]
+	pub items: Option<Vec<item::Item>>,
 }
 
 // workaround for Serde not supporting const generics
 impl<const N: usize> Serialize for Frame<N> {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
 		let mut state = serializer.serialize_struct("Frame", 1)?;
 
 		state.serialize_field("index", &self.index)?;

--- a/peppi/src/model/game.rs
+++ b/peppi/src/model/game.rs
@@ -2,14 +2,11 @@ use std::fmt::{self, Debug};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-	model::{
-		enums::{character, stage},
-		frame,
-		metadata,
-		primitives::Port,
-		slippi,
-	},
+use crate::model::{
+	enums::{character, stage},
+	frame, metadata,
+	primitives::Port,
+	slippi,
 };
 
 pub const NUM_PORTS: usize = 4;
@@ -135,7 +132,8 @@ pub struct Start {
 	pub random_seed: u32,
 
 	/// mostly-redundant copy of the raw start block, for round-tripping
-	#[serde(skip)] #[doc(hidden)]
+	#[serde(skip)]
+	#[doc(hidden)]
 	pub raw_bytes: Vec<u8>,
 
 	/// (added: v1.5)
@@ -218,7 +216,8 @@ pub struct Game {
 	pub metadata: metadata::Metadata,
 	#[serde(rename = "metadata")]
 	pub metadata_raw: serde_json::Map<String, serde_json::Value>,
-	#[serde(skip)] #[doc(hidden)]
+	#[serde(skip)]
+	#[doc(hidden)]
 	pub gecko_codes: Option<GeckoCodes>,
 }
 

--- a/peppi/src/model/item.rs
+++ b/peppi/src/model/item.rs
@@ -1,9 +1,9 @@
-use serde::Serialize;
-use peppi_derive::Arrow;
 use crate::model::{
 	enums::item::{State, Type},
 	primitives::{Direction, Port, Position, Velocity},
 };
+use peppi_derive::Arrow;
+use serde::Serialize;
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Arrow)]
 pub struct Item {
@@ -16,7 +16,9 @@ pub struct Item {
 	pub damage: u16,
 	pub timer: f32,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "3.2")] pub misc: Option<[u8; 4]>,
+	#[slippi(version = "3.2")]
+	pub misc: Option<[u8; 4]>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	#[slippi(version = "3.5")] pub owner: Option<Option<Port>>,
+	#[slippi(version = "3.5")]
+	pub owner: Option<Option<Port>>,
 }

--- a/peppi/src/model/primitives.rs
+++ b/peppi/src/model/primitives.rs
@@ -1,9 +1,11 @@
-use std::fmt::{self, Debug, Display, Formatter};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use serde::{Deserialize, Serialize};
 use peppi_derive::Arrow;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Debug, Display, Formatter};
 
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize, IntoPrimitive, TryFromPrimitive)]
+#[derive(
+	Clone, Copy, Debug, PartialEq, Deserialize, Serialize, IntoPrimitive, TryFromPrimitive,
+)]
 #[repr(u8)]
 pub enum Port {
 	P1 = 0,
@@ -32,7 +34,10 @@ impl Default for Port {
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
-pub enum Direction { Left, Right }
+pub enum Direction {
+	Left,
+	Right,
+}
 
 impl Default for Direction {
 	fn default() -> Self {

--- a/peppi/src/model/pseudo_enum.rs
+++ b/peppi/src/model/pseudo_enum.rs
@@ -10,7 +10,7 @@ impl std::fmt::Display for ConversionError {
 	}
 }
 
-impl std::error::Error for ConversionError { }
+impl std::error::Error for ConversionError {}
 
 // An open "enum" that supports named and unnamed values.
 // Used when not all possible values are known.

--- a/peppi/src/model/slippi.rs
+++ b/peppi/src/model/slippi.rs
@@ -20,7 +20,10 @@ impl From<std::num::ParseIntError> for ParseVersionError {
 impl TryFrom<&str> for Version {
 	type Error = ParseVersionError;
 	fn try_from(s: &str) -> Result<Version, Self::Error> {
-		let v: Vec<u8> = s.split('.').map(|s| s.parse::<u8>()).collect::<Result<Vec<u8>, std::num::ParseIntError>>()?;
+		let v: Vec<u8> = s
+			.split('.')
+			.map(|s| s.parse::<u8>())
+			.collect::<Result<Vec<u8>, std::num::ParseIntError>>()?;
 		match v.len() {
 			0 => unreachable!(),
 			1 => Ok(Version(v[0], 0, 0)),

--- a/peppi/src/serde/arrow.rs
+++ b/peppi/src/serde/arrow.rs
@@ -1,20 +1,12 @@
 use arrow::{
-	array::{
-		ArrayRef,
-		ArrayBuilder,
-		StructArray,
-	},
+	array::{ArrayBuilder, ArrayRef, StructArray},
 	datatypes::DataType,
 };
 
-use crate::{
-	model::{
-		enums::action_state,
-		frame,
-		game,
-		item,
-		primitives::{Direction, Port},
-	},
+use crate::model::{
+	enums::action_state,
+	frame, game, item,
+	primitives::{Direction, Port},
 };
 
 use peppi_arrow::{Arrow, Context, SlippiVersion};
@@ -64,11 +56,7 @@ macro_rules! arrow {
 	}
 }
 
-arrow!(
-	Port: u8,
-	Direction: u8,
-	action_state::State: u16,
-);
+arrow!(Port: u8, Direction: u8, action_state::State: u16,);
 
 #[derive(Clone, Copy, Debug)]
 struct PeppiContext {
@@ -94,7 +82,10 @@ fn context(game: &game::Game, opts: Option<Opts>) -> PeppiContext {
 	}
 }
 
-fn _frames_to_arrow<const N: usize>(frames: &[frame::Frame<N>], context: PeppiContext) -> StructArray {
+fn _frames_to_arrow<const N: usize>(
+	frames: &[frame::Frame<N>],
+	context: PeppiContext,
+) -> StructArray {
 	let mut builder = frame::Frame::<N>::builder(frames.len(), context);
 	for frame in frames {
 		frame.write(&mut builder, context);
@@ -120,7 +111,10 @@ struct FrameItem {
 	item: item::Item,
 }
 
-fn _items_to_arrow<const N: usize>(frames: &[frame::Frame<N>], context: PeppiContext) -> Option<StructArray> {
+fn _items_to_arrow<const N: usize>(
+	frames: &[frame::Frame<N>],
+	context: PeppiContext,
+) -> Option<StructArray> {
 	if frames[0].items.is_some() {
 		let len = frames.iter().map(|f| f.items.as_ref().unwrap().len()).sum();
 		let mut builder = FrameItem::builder(len, context);
@@ -129,7 +123,8 @@ fn _items_to_arrow<const N: usize>(frames: &[frame::Frame<N>], context: PeppiCon
 				FrameItem {
 					frame_index: u32::try_from(idx).unwrap(),
 					item: *item,
-				}.write(&mut builder, context);
+				}
+				.write(&mut builder, context);
 			}
 		}
 		Some(builder.finish())

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -6,28 +6,25 @@ use std::{
 
 use byteorder::ReadBytesExt;
 use encoding_rs::SHIFT_JIS;
-use log::{info, debug, trace};
+use log::{debug, info, trace};
 use serde_json;
 
 type BE = byteorder::BigEndian;
 
 use crate::{
 	model::{
+		buttons,
 		enums::{
 			action_state::{self, Common, State},
 			attack::Attack,
 			character::{self, Internal},
-			ground,
-			item,
-			stage,
+			ground, item, stage,
 		},
-		buttons,
-		frame::{self, Pre, Post},
-		game::{self, MAX_PLAYERS, NUM_PORTS, Netplay, Player, PlayerType},
+		frame::{self, Post, Pre},
+		game::{self, Netplay, Player, PlayerType, MAX_PLAYERS, NUM_PORTS},
 		item::Item,
 		primitives::{Port, Position, Velocity},
-		slippi,
-		triggers,
+		slippi, triggers,
 	},
 	ubjson,
 };
@@ -40,7 +37,7 @@ const SHEIK_TRANSFORM_FRAME: u32 = 36;
 const DEFAULT_CHAR_STATE: CharState = CharState {
 	character: Internal(255),
 	state: State::Common(Common::WAIT),
-	age: 0
+	age: 0,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -78,9 +75,7 @@ pub struct FrameId {
 
 impl FrameId {
 	fn new(index: i32) -> FrameId {
-		FrameId {
-			index: index,
-		}
+		FrameId { index: index }
 	}
 }
 
@@ -131,7 +126,9 @@ pub struct FrameEvent<Id, Event> {
 }
 
 fn if_more<F, T>(r: &mut &[u8], f: F) -> Result<Option<T>>
-where F: FnOnce(&mut &[u8]) -> Result<T> {
+where
+	F: FnOnce(&mut &[u8]) -> Result<T>,
+{
 	Ok(match r.is_empty() {
 		true => None,
 		_ => Some(f(r)?),
@@ -159,19 +156,34 @@ fn payload_sizes<R: Read>(r: &mut R) -> Result<(usize, HashMap<u8, u16>)> {
 	}
 
 	let mut sizes = HashMap::new();
-	for _ in (0 .. size - 1).step_by(3) {
+	for _ in (0..size - 1).step_by(3) {
 		let code = r.read_u8()?;
 		let size = r.read_u16::<BE>()?;
 		sizes.insert(code, size);
 	}
 
-	info!("Event payload sizes: {{{}}}",
-		sizes.iter().map(|(k, v)| format!("0x{:x}: {}", k, v)).collect::<Vec<_>>().join(", "));
+	info!(
+		"Event payload sizes: {{{}}}",
+		sizes
+			.iter()
+			.map(|(k, v)| format!("0x{:x}: {}", k, v))
+			.collect::<Vec<_>>()
+			.join(", ")
+	);
 
 	Ok((1 + size as usize, sizes)) // +1 byte for the event code
 }
 
-fn player(port: Port, v0: &[u8; 36], is_teams: bool, v1_0: Option<[u8; 8]>, v1_3: Option<[u8; 16]>, v3_9_name: Option<[u8; 31]>, v3_9_code: Option<[u8; 10]>, v3_11: Option<[u8; 29]>) -> Result<Option<Player>> {
+fn player(
+	port: Port,
+	v0: &[u8; 36],
+	is_teams: bool,
+	v1_0: Option<[u8; 8]>,
+	v1_3: Option<[u8; 16]>,
+	v3_9_name: Option<[u8; 31]>,
+	v3_9_code: Option<[u8; 10]>,
+	v3_11: Option<[u8; 29]>,
+) -> Result<Option<Player>> {
 	let mut r = &v0[..];
 	let mut unmapped = [0; 15];
 
@@ -223,14 +235,17 @@ fn player(port: Port, v0: &[u8; 36], is_teams: bool, v1_0: Option<[u8; 8]>, v1_3
 					sd => Some(game::ShieldDrop(sd)),
 				},
 			})
-		},
+		}
 		_ => None,
 	};
 
 	// v1_3
 	let name_tag = v1_3.map(|v1_3| {
 		let first_null = v1_3.iter().position(|&x| x == 0).unwrap_or(16);
-		SHIFT_JIS.decode_without_bom_handling(&v1_3[0..first_null]).0.to_string()
+		SHIFT_JIS
+			.decode_without_bom_handling(&v1_3[0..first_null])
+			.0
+			.to_string()
 	});
 
 	// v3.9
@@ -238,11 +253,17 @@ fn player(port: Port, v0: &[u8; 36], is_teams: bool, v1_0: Option<[u8; 8]>, v1_3
 		Netplay {
 			name: {
 				let first_null = name.iter().position(|&x| x == 0).unwrap_or(31);
-				SHIFT_JIS.decode_without_bom_handling(&name[0..first_null]).0.to_string()
+				SHIFT_JIS
+					.decode_without_bom_handling(&name[0..first_null])
+					.0
+					.to_string()
 			},
 			code: {
 				let first_null = code.iter().position(|&x| x == 0).unwrap_or(10);
-				SHIFT_JIS.decode_without_bom_handling(&code[0..first_null]).0.to_string()
+				SHIFT_JIS
+					.decode_without_bom_handling(&code[0..first_null])
+					.0
+					.to_string()
 			},
 			// v3.11
 			suid: v3_11.map(|v3_11| {
@@ -369,24 +390,29 @@ fn game_start(mut r: &mut &[u8]) -> Result<game::Start> {
 
 	let is_pal = if_more(r, |r| Ok(r.read_u8()? != 0))?;
 	let is_frozen_ps = if_more(r, |r| Ok(r.read_u8()? != 0))?;
-	let scene = if_more(r, |r| Ok(game::Scene {
-		minor: r.read_u8()?,
-		major: r.read_u8()?,
-	}))?;
+	let scene = if_more(r, |r| {
+		Ok(game::Scene {
+			minor: r.read_u8()?,
+			major: r.read_u8()?,
+		})
+	})?;
 
 	let players_v3_9 = match r.is_empty() {
 		true => ([None, None, None, None], [None, None, None, None]),
-		_ => ([
-			Some(player_bytes_v3_9_name(&mut r)?),
-			Some(player_bytes_v3_9_name(&mut r)?),
-			Some(player_bytes_v3_9_name(&mut r)?),
-			Some(player_bytes_v3_9_name(&mut r)?),
-		], [
-			Some(player_bytes_v3_9_code(&mut r)?),
-			Some(player_bytes_v3_9_code(&mut r)?),
-			Some(player_bytes_v3_9_code(&mut r)?),
-			Some(player_bytes_v3_9_code(&mut r)?),
-		]),
+		_ => (
+			[
+				Some(player_bytes_v3_9_name(&mut r)?),
+				Some(player_bytes_v3_9_name(&mut r)?),
+				Some(player_bytes_v3_9_name(&mut r)?),
+				Some(player_bytes_v3_9_name(&mut r)?),
+			],
+			[
+				Some(player_bytes_v3_9_code(&mut r)?),
+				Some(player_bytes_v3_9_code(&mut r)?),
+				Some(player_bytes_v3_9_code(&mut r)?),
+				Some(player_bytes_v3_9_code(&mut r)?),
+			],
+		),
 	};
 
 	let players_v3_11 = match r.is_empty() {
@@ -400,8 +426,17 @@ fn game_start(mut r: &mut &[u8]) -> Result<game::Start> {
 	};
 
 	let mut players = Vec::<Player>::new();
-	for n in 0 .. NUM_PORTS {
-		if let Some(p) = player(Port::try_from(n as u8).unwrap(), &players_v0[n], is_teams, players_v1_0[n], players_v1_3[n], players_v3_9.0[n], players_v3_9.1[n], players_v3_11[n])? {
+	for n in 0..NUM_PORTS {
+		if let Some(p) = player(
+			Port::try_from(n as u8).unwrap(),
+			&players_v0[n],
+			is_teams,
+			players_v1_0[n],
+			players_v1_3[n],
+			players_v3_9.0[n],
+			players_v3_9.1[n],
+			players_v3_11[n],
+		)? {
 			players.push(p);
 		}
 	}
@@ -493,9 +528,11 @@ fn item(r: &mut &[u8]) -> Result<FrameEvent<FrameId, Item>> {
 			timer: r.read_f32::<BE>()?,
 			id: r.read_u32::<BE>()?,
 			// v3.2
-			misc: if_more(r, |r| Ok([r.read_u8()?, r.read_u8()?, r.read_u8()?, r.read_u8()?]))?,
+			misc: if_more(r, |r| {
+				Ok([r.read_u8()?, r.read_u8()?, r.read_u8()?, r.read_u8()?])
+			})?,
 			// v3.6
-			owner: if_more(r, |r| Ok(Port::try_from(r.read_u8()?).ok()))?
+			owner: if_more(r, |r| Ok(Port::try_from(r.read_u8()?).ok()))?,
 		},
 	})
 }
@@ -508,17 +545,26 @@ fn item(r: &mut &[u8]) -> Result<FrameEvent<FrameId, Item>> {
 fn predict_character(id: PortId, last_char_states: &[CharState; NUM_PORTS]) -> Internal {
 	let prev = last_char_states[id.port as usize];
 	match prev.state {
-		State::Zelda(action_state::Zelda::TRANSFORM_GROUND) |
-		State::Zelda(action_state::Zelda::TRANSFORM_AIR)
-			if prev.age >= ZELDA_TRANSFORM_FRAME => Internal::SHEIK,
-		State::Sheik(action_state::Sheik::TRANSFORM_GROUND) |
-		State::Sheik(action_state::Sheik::TRANSFORM_AIR)
-			if prev.age >= SHEIK_TRANSFORM_FRAME => Internal::ZELDA,
+		State::Zelda(action_state::Zelda::TRANSFORM_GROUND)
+		| State::Zelda(action_state::Zelda::TRANSFORM_AIR)
+			if prev.age >= ZELDA_TRANSFORM_FRAME =>
+		{
+			Internal::SHEIK
+		}
+		State::Sheik(action_state::Sheik::TRANSFORM_GROUND)
+		| State::Sheik(action_state::Sheik::TRANSFORM_AIR)
+			if prev.age >= SHEIK_TRANSFORM_FRAME =>
+		{
+			Internal::ZELDA
+		}
 		_ => prev.character,
 	}
 }
 
-fn frame_pre(r: &mut &[u8], last_char_states: &[CharState; NUM_PORTS]) -> Result<FrameEvent<PortId, Pre>> {
+fn frame_pre(
+	r: &mut &[u8],
+	last_char_states: &[CharState; NUM_PORTS],
+) -> Result<FrameEvent<PortId, Pre>> {
 	let id = PortId::new(r.read_i32::<BE>()?, r.read_u8()?, r.read_u8()? != 0)?;
 	trace!("Pre-Frame Update: {:?}", id);
 
@@ -568,21 +614,26 @@ fn frame_pre(r: &mut &[u8], last_char_states: &[CharState; NUM_PORTS]) -> Result
 			raw_analog_x: if_more(r, |r| r.read_u8())?,
 			// v1.4
 			damage: if_more(r, |r| r.read_f32::<BE>())?,
-		}
+		},
 	})
 }
 
 fn flags(buf: &[u8; 5]) -> frame::StateFlags {
 	frame::StateFlags(
-		(buf[0] as u64) +
-		((buf[1] as u64) << 08) +
-		((buf[2] as u64) << 16) +
-		((buf[3] as u64) << 24) +
-		((buf[4] as u64) << 32)
+		(buf[0] as u64)
+			+ ((buf[1] as u64) << 08)
+			+ ((buf[2] as u64) << 16)
+			+ ((buf[3] as u64) << 24)
+			+ ((buf[4] as u64) << 32),
 	)
 }
 
-fn update_last_char_state(id: PortId, character: Internal, state: State, last_char_states: &mut [CharState; NUM_PORTS]) {
+fn update_last_char_state(
+	id: PortId,
+	character: Internal,
+	state: State,
+	last_char_states: &mut [CharState; NUM_PORTS],
+) {
 	const Z_AIR: State = State::Zelda(action_state::Zelda::TRANSFORM_AIR);
 	const Z_GROUND: State = State::Zelda(action_state::Zelda::TRANSFORM_GROUND);
 	const S_AIR: State = State::Sheik(action_state::Sheik::TRANSFORM_AIR);
@@ -601,16 +652,17 @@ fn update_last_char_state(id: PortId, character: Internal, state: State, last_ch
 			// `TRANSFORM_GROUND_ENDING` on the next frame. This delays the character
 			// switch by one frame, so we cap `age` at its previous value so as not to
 			// confuse `predict_character`.
-			(Z_AIR, Z_GROUND) | (Z_GROUND, Z_AIR) =>
-				min(ZELDA_TRANSFORM_FRAME - 1, prev.age + 1),
-			(S_AIR, S_GROUND) | (S_GROUND, S_AIR) =>
-				min(SHEIK_TRANSFORM_FRAME - 1, prev.age + 1),
+			(Z_AIR, Z_GROUND) | (Z_GROUND, Z_AIR) => min(ZELDA_TRANSFORM_FRAME - 1, prev.age + 1),
+			(S_AIR, S_GROUND) | (S_GROUND, S_AIR) => min(SHEIK_TRANSFORM_FRAME - 1, prev.age + 1),
 			_ => 0,
 		},
 	};
 }
 
-fn frame_post(r: &mut &[u8], last_char_states: &mut [CharState; NUM_PORTS]) -> Result<FrameEvent<PortId, Post>> {
+fn frame_post(
+	r: &mut &[u8],
+	last_char_states: &mut [CharState; NUM_PORTS],
+) -> Result<FrameEvent<PortId, Post>> {
 	let id = PortId::new(r.read_i32::<BE>()?, r.read_u8()?, r.read_u8()? != 0)?;
 	trace!("Post-Frame Update: {:?}", id);
 
@@ -647,43 +699,45 @@ fn frame_post(r: &mut &[u8], last_char_states: &mut [CharState; NUM_PORTS]) -> R
 	let airborne = if_more(r, |r| Ok(r.read_u8()? != 0))?;
 	let ground = if_more(r, |r| Ok(ground::Ground(r.read_u16::<BE>()?)))?;
 	let jumps = if_more(r, |r| r.read_u8())?;
-	let l_cancel = if_more(r, |r| Ok(
-		match r.read_u8()? {
+	let l_cancel = if_more(r, |r| {
+		Ok(match r.read_u8()? {
 			0 => None,
 			1 => Some(true),
 			2 => Some(false),
 			i => return Err(err!("invalid L-Cancel value: {}", i)),
-		}
-	))?;
+		})
+	})?;
 
 	// v2.1
 	let hurtbox_state = if_more(r, |r| Ok(frame::HurtboxState(r.read_u8()?)))?;
 
 	// v3.5
-	let velocities = if_more(r, |r| Ok({
-		let autogenous_x_air = r.read_f32::<BE>()?;
-		let autogenous_y = r.read_f32::<BE>()?;
-		let knockback_x = r.read_f32::<BE>()?;
-		let knockback_y = r.read_f32::<BE>()?;
-		let autogenous_x_ground = r.read_f32::<BE>()?;
-		frame::Velocities {
-			autogenous: Velocity {
-				x: match airborne.unwrap() {
-					true => autogenous_x_air,
-					_ => autogenous_x_ground,
+	let velocities = if_more(r, |r| {
+		Ok({
+			let autogenous_x_air = r.read_f32::<BE>()?;
+			let autogenous_y = r.read_f32::<BE>()?;
+			let knockback_x = r.read_f32::<BE>()?;
+			let knockback_y = r.read_f32::<BE>()?;
+			let autogenous_x_ground = r.read_f32::<BE>()?;
+			frame::Velocities {
+				autogenous: Velocity {
+					x: match airborne.unwrap() {
+						true => autogenous_x_air,
+						_ => autogenous_x_ground,
+					},
+					y: autogenous_y,
 				},
-				y: autogenous_y,
-			},
-			autogenous_x: frame::AutogenousXVelocity {
-				air: autogenous_x_air,
-				ground: autogenous_x_ground,
-			},
-			knockback: Velocity {
-				x: knockback_x,
-				y: knockback_y,
-			},
-		}
-	}))?;
+				autogenous_x: frame::AutogenousXVelocity {
+					air: autogenous_x_air,
+					ground: autogenous_x_ground,
+				},
+				knockback: Velocity {
+					x: knockback_x,
+					y: knockback_y,
+				},
+			}
+		})
+	})?;
 
 	// v3.8
 	let hitlag = if_more(r, |r| r.read_f32::<BE>())?;
@@ -736,29 +790,49 @@ pub trait Handlers {
 	// https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md
 
 	/// List of enabled Gecko codes. Currently unparsed.
-	fn gecko_codes(&mut self, _codes: &[u8], _actual_size: u16) -> Result<()> { Ok(()) }
+	fn gecko_codes(&mut self, _codes: &[u8], _actual_size: u16) -> Result<()> {
+		Ok(())
+	}
 
 	/// How the game is set up; also includes the version of the extraction code.
-	fn game_start(&mut self, _: game::Start) -> Result<()> { Ok(()) }
+	fn game_start(&mut self, _: game::Start) -> Result<()> {
+		Ok(())
+	}
 	/// The end of the game.
-	fn game_end(&mut self, _: game::End) -> Result<()> { Ok(()) }
+	fn game_end(&mut self, _: game::End) -> Result<()> {
+		Ok(())
+	}
 	/// Miscellaneous data not directly provided by Melee.
-	fn metadata(&mut self, _: serde_json::Map<String, serde_json::Value>) -> Result<()> { Ok(()) }
+	fn metadata(&mut self, _: serde_json::Map<String, serde_json::Value>) -> Result<()> {
+		Ok(())
+	}
 
 	/// RNG seed and frame number at the start of a frame's processing.
-	fn frame_start(&mut self, _: FrameEvent<FrameId, frame::Start>) -> Result<()> { Ok(()) }
+	fn frame_start(&mut self, _: FrameEvent<FrameId, frame::Start>) -> Result<()> {
+		Ok(())
+	}
 	/// Pre-frame update, collected right before controller inputs are used to figure out the character's next action. Used to reconstruct a replay.
-	fn frame_pre(&mut self, _: FrameEvent<PortId, Pre>) -> Result<()> { Ok(()) }
+	fn frame_pre(&mut self, _: FrameEvent<PortId, Pre>) -> Result<()> {
+		Ok(())
+	}
 	/// Post-frame update, collected at the end of the Collision detection which is the last consideration of the game engine. Useful for making decisions about game states, such as computing stats.
-	fn frame_post(&mut self, _: FrameEvent<PortId, Post>) -> Result<()> { Ok(()) }
+	fn frame_post(&mut self, _: FrameEvent<PortId, Post>) -> Result<()> {
+		Ok(())
+	}
 	/// Indicates an entire frame's worth of data has been transferred/processed.
-	fn frame_end(&mut self, _: FrameEvent<FrameId, frame::End>) -> Result<()> { Ok(()) }
+	fn frame_end(&mut self, _: FrameEvent<FrameId, frame::End>) -> Result<()> {
+		Ok(())
+	}
 
 	/// One event per frame per item, with a maximum of 15 updates per frame. Can be used for stats, training AIs, or visualization engines to handle items. Items include projectiles like lasers or needles.
-	fn item(&mut self, _: FrameEvent<FrameId, Item>) -> Result<()> { Ok(()) }
+	fn item(&mut self, _: FrameEvent<FrameId, Item>) -> Result<()> {
+		Ok(())
+	}
 
 	/// Called after all parse events have been handled.
-	fn finalize(&mut self) -> Result<()> { Ok(()) }
+	fn finalize(&mut self) -> Result<()> {
+		Ok(())
+	}
 }
 
 fn expect_bytes<R: Read>(r: &mut R, expected: &[u8]) -> Result<()> {
@@ -773,7 +847,7 @@ fn expect_bytes<R: Read>(r: &mut R, expected: &[u8]) -> Result<()> {
 
 fn handle_splitter_event(buf: &[u8], accumulator: &mut Option<Vec<u8>>) -> Result<Option<u8>> {
 	assert_eq!(buf.len(), 516);
-	let actual_size = (&buf[512 .. 514]).read_u16::<BE>()?;
+	let actual_size = (&buf[512..514]).read_u16::<BE>()?;
 	assert!(actual_size <= 512);
 	let wrapped_event = buf[514];
 	let is_final = buf[515] != 0;
@@ -785,7 +859,7 @@ fn handle_splitter_event(buf: &[u8], accumulator: &mut Option<Vec<u8>>) -> Resul
 
 	// bytes beyond `actual_size` are meaningless,
 	// but save them anyway for lossless round-tripping
-	accumulator.extend_from_slice(&buf[0 .. 512]);
+	accumulator.extend_from_slice(&buf[0..512]);
 
 	Ok(match is_final {
 		true => Some(wrapped_event),
@@ -799,20 +873,23 @@ fn handle_splitter_event(buf: &[u8], accumulator: &mut Option<Vec<u8>>) -> Resul
 ///
 /// Returns the number of bytes read by this function.
 fn event<R: Read, H: Handlers>(
-		mut r: R,
-		payload_sizes: &HashMap<u8, u16>,
-		last_char_states: &mut [CharState; NUM_PORTS],
-		handlers: &mut H,
-		splitter_accumulator: &mut Option<Vec<u8>>,
-	) -> Result<(usize, Option<Event>)> {
+	mut r: R,
+	payload_sizes: &HashMap<u8, u16>,
+	last_char_states: &mut [CharState; NUM_PORTS],
+	handlers: &mut H,
+	splitter_accumulator: &mut Option<Vec<u8>>,
+) -> Result<(usize, Option<Event>)> {
 	let mut code = r.read_u8()?;
 	debug!("Event: {:#x}", code);
 
-	let size = *payload_sizes.get(&code).ok_or_else(|| err!("unknown event: {}", code))? as usize;
+	let size = *payload_sizes
+		.get(&code)
+		.ok_or_else(|| err!("unknown event: {}", code))? as usize;
 	let mut buf = vec![0; size];
 	r.read_exact(&mut *buf)?;
 
-	if code == 0x10 { // message splitter
+	if code == 0x10 {
+		// message splitter
 		if let Some(wrapped_event) = handle_splitter_event(&buf, splitter_accumulator)? {
 			code = wrapped_event;
 			buf.clear();
@@ -847,12 +924,20 @@ pub struct Opts {
 }
 
 /// Parses a Slippi replay from `r`, passing events to the callbacks in `handlers` as they occur.
-pub fn deserialize<R: Read, H: Handlers>(mut r: &mut R, handlers: &mut H, opts: Option<Opts>) -> Result<()> {
+pub fn deserialize<R: Read, H: Handlers>(
+	mut r: &mut R,
+	handlers: &mut H,
+	opts: Option<Opts>,
+) -> Result<()> {
 	// For speed, assume the `raw` element comes first and handle it manually.
 	// The official JS parser does this too, so it should be reliable.
-	expect_bytes(&mut r,
+	expect_bytes(
+		&mut r,
 		// top-level opening brace, `raw` key & type ("{U\x03raw[$U#l")
-		&[0x7b, 0x55, 0x03, 0x72, 0x61, 0x77, 0x5b, 0x24, 0x55, 0x23, 0x6c])?;
+		&[
+			0x7b, 0x55, 0x03, 0x72, 0x61, 0x77, 0x5b, 0x24, 0x55, 0x23, 0x6c,
+		],
+	)?;
 
 	let raw_len = r.read_u32::<BE>()? as usize;
 	let (mut bytes_read, payload_sizes) = payload_sizes(&mut r)?;
@@ -884,12 +969,20 @@ pub fn deserialize<R: Read, H: Handlers>(mut r: &mut R, handlers: &mut H, opts: 
 	}
 
 	if raw_len != 0 && bytes_read != raw_len {
-		return Err(err!("failed to consume expected number of bytes: {}, {}", raw_len, bytes_read));
+		return Err(err!(
+			"failed to consume expected number of bytes: {}, {}",
+			raw_len,
+			bytes_read
+		));
 	}
 
-	expect_bytes(&mut r,
+	expect_bytes(
+		&mut r,
 		// `metadata` key & type ("U\x08metadata{")
-		&[0x55, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x7b])?;
+		&[
+			0x55, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x7b,
+		],
+	)?;
 
 	// Since we already read the opening "{" from the `metadata` value,
 	// we know it's a map. `parse_map` will consume the corresponding "}".

--- a/peppi/src/ubjson/de.rs
+++ b/peppi/src/ubjson/de.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Result, Error, ErrorKind};
+use std::io::{Error, ErrorKind, Read, Result};
 
 use byteorder::{BigEndian, ReadBytesExt};
 use serde_json::{Map, Value};
@@ -18,7 +18,9 @@ fn to_val<R: Read>(r: &mut R) -> Result<Value> {
 			c => Err(err!("Expected 0x55 for string length, but got: {}", c)),
 		},
 		// "l": i32
-		0x6c => Ok(Value::Number(serde_json::Number::from(r.read_i32::<BigEndian>()?))),
+		0x6c => Ok(Value::Number(serde_json::Number::from(
+			r.read_i32::<BigEndian>()?,
+		))),
 		// "{": map
 		0x7b => Ok(Value::Object(to_map(r)?)),
 		c => Err(err!("unexpected UBJSON value type: {}", c)),
@@ -36,7 +38,10 @@ fn to_key<R: Read>(r: &mut R) -> Result<Option<String>> {
 pub fn to_map<R: Read>(r: &mut R) -> Result<Map<String, Value>> {
 	let mut m = Map::new();
 	while match to_key(r)? {
-		Some(k) => {m.insert(k, to_val(r)?); true},
+		Some(k) => {
+			m.insert(k, to_val(r)?);
+			true
+		}
 		None => false,
 	} {}
 	Ok(m)

--- a/peppi/src/ubjson/ser.rs
+++ b/peppi/src/ubjson/ser.rs
@@ -1,4 +1,4 @@
-use std::io::{Write, Result};
+use std::io::{Result, Write};
 
 use byteorder::{BigEndian, WriteBytesExt};
 use serde_json::{Map, Value};
@@ -18,11 +18,11 @@ pub fn from_map<W: Write>(w: &mut W, map: &Map<String, Value>) -> Result<()> {
 			Value::String(s) => {
 				write!(w, "S")?;
 				write_utf8(w, s)?;
-			},
+			}
 			Value::Number(n) => {
 				write!(w, "l")?;
 				w.write_i32::<BigEndian>(n.as_i64().unwrap().try_into().unwrap())?;
-			},
+			}
 			Value::Object(o) => {
 				write!(w, "{{")?;
 				from_map(w, o)?;


### PR DESCRIPTION
I suggest using the official Rust code formatter `rustfmt`: https://github.com/rust-lang/rustfmt

I added a `rustfmt.toml` file that can define custom configs (see https://rust-lang.github.io/rustfmt/?version=v1.5.0). Right now it is setup to use tabs for indentation to fit the project (spaces are the default). The file can also be made hidden `.rustfmt.toml`.

I know code formatting can be a touchy subject. I think the decision should be left to the maintainer. You can effectively disable rustfmt by setting [disable_all_formatting](https://rust-lang.github.io/rustfmt/?version=v1.5.0&search=#disable_all_formatting) to true.

Whichever approach is used, having a rustfmt config file should make maintaining the project and contributing to the project a little bit easier.