### PR TITLE
Add info module

### DIFF
--- a/peppi/Cargo.toml
+++ b/peppi/Cargo.toml
@@ -18,6 +18,8 @@ peppi-arrow = { path = "../peppi-arrow" }
 peppi-derive = { path = "../peppi-derive" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
+regex = { version = "1", default-features = false, features = ["perf"] }
+lazy_static = "1.4.0"
 
 [lib]
 name = "peppi"

--- a/peppi/Cargo.toml
+++ b/peppi/Cargo.toml
@@ -18,8 +18,6 @@ peppi-arrow = { path = "../peppi-arrow" }
 peppi-derive = { path = "../peppi-derive" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-regex = { version = "1", default-features = false, features = ["perf"] }
-lazy_static = "1.4.0"
 
 [lib]
 name = "peppi"

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -1,222 +1,186 @@
-pub mod external {
+mod external {
     use crate::model::enums::character::External;
 
     #[non_exhaustive]
     #[derive(Clone, Debug)]
     pub struct Info {
-        pub external: External,
         pub short_name: &'static str,
         pub long_name: &'static str,
     }
 
     info!(External => Info {
         CAPTAIN_FALCON {
-            external: External::CAPTAIN_FALCON,
             short_name: "Falcon",
             long_name: "Captain Falcon",
         };
 
         DONKEY_KONG {
-            external: External::DONKEY_KONG,
             short_name: "DK",
             long_name: "Donkey Kong",
         };
 
         FOX {
-            external: External::FOX,
             short_name: "Fox",
             long_name: "Fox",
         };
 
         GAME_AND_WATCH {
-            external: External::GAME_AND_WATCH,
             short_name: "G&W",
             long_name: "Game and Watch",
         };
 
         KIRBY {
-            external: External::KIRBY,
             short_name: "Kirby",
             long_name: "Kirby",
         };
 
         BOWSER {
-            external: External::BOWSER,
             short_name: "Bowser",
             long_name: "Bowser",
         };
 
         LINK {
-            external: External::LINK,
             short_name: "Link",
             long_name: "Link",
         };
 
         LUIGI {
-            external: External::LUIGI,
             short_name: "Luigi",
             long_name: "Luigi",
         };
 
         MARIO {
-            external: External::MARIO,
             short_name: "Mario",
             long_name: "Mario",
         };
 
         MARTH {
-            external: External::MARTH,
             short_name: "Marth",
             long_name: "Marth",
         };
 
         MEWTWO {
-            external: External::MEWTWO,
             short_name: "Mewtwo",
             long_name: "Mewtwo",
         };
 
         NESS {
-            external: External::NESS,
             short_name: "Ness",
             long_name: "Ness",
         };
 
         PEACH {
-            external: External::PEACH,
             short_name: "Peach",
             long_name: "Peach",
         };
 
         PIKACHU {
-            external: External::PIKACHU,
             short_name: "Pika",
             long_name: "Pikachu",
         };
 
         ICE_CLIMBERS {
-            external: External::ICE_CLIMBERS,
             short_name: "ICs",
             long_name: "Ice Climbers",
         };
 
         JIGGLYPUFF {
-            external: External::JIGGLYPUFF,
             short_name: "Puff",
             long_name: "Jigglypuff",
         };
 
         SAMUS {
-            external: External::SAMUS,
             short_name: "Samus",
             long_name: "Samus",
         };
 
         YOSHI {
-            external: External::YOSHI,
             short_name: "Yoshi",
             long_name: "Yoshi",
         };
 
         ZELDA {
-            external: External::ZELDA,
             short_name: "Zelda",
             long_name: "Zelda",
         };
 
         SHEIK {
-            external: External::SHEIK,
             short_name: "Sheik",
             long_name: "Sheik",
         };
 
         FALCO {
-            external: External::FALCO,
             short_name: "Falco",
             long_name: "Falco",
         };
 
         YOUNG_LINK {
-            external: External::YOUNG_LINK,
             short_name: "YL",
             long_name: "Young Link",
         };
 
         DR_MARIO {
-            external: External::DR_MARIO,
             short_name: "Doc",
             long_name: "Dr. Mario",
         };
 
         ROY {
-            external: External::ROY,
             short_name: "Roy",
             long_name: "Roy",
         };
 
         PICHU {
-            external: External::PICHU,
             short_name: "Pichu",
             long_name: "Pichu",
         };
 
         GANONDORF {
-            external: External::GANONDORF,
             short_name: "Ganon",
             long_name: "Ganondorf",
         };
 
         MASTER_HAND {
-            external: External::MASTER_HAND,
             short_name: "Master Hand",
             long_name: "Master Hand",
         };
 
         WIRE_FRAME_MALE {
-            external: External::WIRE_FRAME_MALE,
             short_name: "Male Wireframe",
             long_name: "Male Wireframe",
         };
 
         WIRE_FRAME_FEMALE {
-            external: External::WIRE_FRAME_FEMALE,
             short_name: "Female Wireframe",
             long_name: "Female Wireframe",
         };
 
         GIGA_BOWSER {
-            external: External::GIGA_BOWSER,
             short_name: "Giga Bowser",
             long_name: "Giga Bowser",
         };
 
         CRAZY_HAND {
-            external: External::CRAZY_HAND,
             short_name: "Crazy Hand",
             long_name: "Crazy Hand",
         };
 
         SANDBAG {
-            external: External::SANDBAG,
             short_name: "Sandbag",
             long_name: "Sandbag",
         };
 
         POPO {
-            external: External::POPO,
             short_name: "Popo",
             long_name: "Popo",
         };
     });
 }
 
-pub mod internal {
+mod internal {
     use crate::model::enums::character::Internal;
-
     #[non_exhaustive]
     #[derive(Clone, Debug)]
     pub struct Info {
-        pub internal: Internal,
         pub jumpsquat: u8,
         pub empty_landing_lag: u8,
         pub can_walljump: bool,
@@ -224,210 +188,180 @@ pub mod internal {
 
     info!(Internal => Info {
         MARIO {
-            internal: Internal::MARIO,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: true,
         };
 
         FOX {
-            internal: Internal::FOX,
             jumpsquat: 3,
             empty_landing_lag: 4,
             can_walljump: true,
         };
 
         CAPTAIN_FALCON {
-            internal: Internal::CAPTAIN_FALCON,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: true,
         };
 
         DONKEY_KONG {
-            internal: Internal::DONKEY_KONG,
             jumpsquat: 5,
             empty_landing_lag: 5,
             can_walljump: false,
         };
 
         KIRBY {
-            internal: Internal::KIRBY,
             jumpsquat: 3,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         BOWSER {
-            internal: Internal::BOWSER,
             jumpsquat: 8,
             empty_landing_lag: 6,
             can_walljump: false,
         };
 
         LINK {
-            internal: Internal::LINK,
             jumpsquat: 6,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         SHEIK {
-            internal: Internal::SHEIK,
             jumpsquat: 3,
             empty_landing_lag: 4,
             can_walljump: true,
         };
 
         NESS {
-            internal: Internal::NESS,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         PEACH {
-            internal: Internal::PEACH,
             jumpsquat: 5,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         POPO {
-            internal: Internal::POPO,
             jumpsquat: 3,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         NANA {
-            internal: Internal::NANA,
             jumpsquat: 3,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         PIKACHU {
-            internal: Internal::PIKACHU,
             jumpsquat: 3,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         SAMUS {
-            internal: Internal::SAMUS,
             jumpsquat: 3,
             empty_landing_lag: 4,
             can_walljump: true,
         };
 
         YOSHI {
-            internal: Internal::YOSHI,
             jumpsquat: 5,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         JIGGLYPUFF {
-            internal: Internal::JIGGLYPUFF,
             jumpsquat: 5,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         MEWTWO {
-            internal: Internal::MEWTWO,
             jumpsquat: 5,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         LUIGI {
-            internal: Internal::LUIGI,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         MARTH {
-            internal: Internal::MARTH,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         ZELDA {
-            internal: Internal::ZELDA,
             jumpsquat: 6,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         YOUNG_LINK {
-            internal: Internal::YOUNG_LINK,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: true,
         };
 
         DR_MARIO {
-            internal: Internal::DR_MARIO,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         FALCO {
-            internal: Internal::FALCO,
             jumpsquat: 5,
             empty_landing_lag: 4,
             can_walljump: true,
         };
 
         PICHU {
-            internal: Internal::PICHU,
             jumpsquat: 3,
             empty_landing_lag: 2,
             can_walljump: true,
         };
 
         GAME_AND_WATCH {
-            internal: Internal::GAME_AND_WATCH,
             jumpsquat: 4,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         GANONDORF {
-            internal: Internal::GANONDORF,
             jumpsquat: 6,
             empty_landing_lag: 5,
             can_walljump: false,
         };
 
         ROY {
-            internal: Internal::ROY,
             jumpsquat: 5,
             empty_landing_lag: 4,
             can_walljump: false,
         };
 
         WIRE_FRAME_MALE {
-            internal: Internal::WIRE_FRAME_MALE,
             jumpsquat: 7,
             empty_landing_lag: 15,
             can_walljump: false,
         };
 
         WIRE_FRAME_FEMALE {
-            internal: Internal::WIRE_FRAME_FEMALE,
             jumpsquat: 7,
             empty_landing_lag: 15,
             can_walljump: false,
         };
 
         GIGA_BOWSER {
-            internal: Internal::GIGA_BOWSER,
             jumpsquat: 6,
             empty_landing_lag: 30,
             can_walljump: false,

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -208,43 +208,6 @@ pub mod external {
             long: "Popo",
         };
     });
-
-
-    info_regex!(Info {
-        CAPTAIN_FALCON: r"(?i-u)^(capt(ain|\.)?[ _]?)?falcon$",
-        DONKEY_KONG: r"(?i-u)^dk|(donkey[ _]?kong$",
-        FOX: r"(?i-u)^fox$",
-        GAME_AND_WATCH: r"(?i-u)^(g|game)[ _]?(and|&|n)[ _]?(w|watch)$",
-        KIRBY: r"(?i-u)^kirby$",
-        BOWSER: r"(?i-u)^bowser$",
-        LINK: r"(?i-u)^link$",
-        LUIGI: r"(?i-u)^luigi$",
-        MARIO: r"(?i-u)^mario$",
-        MARTH: r"(?i-u)^marth$",
-        MEWTWO: r"(?i-u)^mewtwo|mew2|m2$",
-        NESS: r"(?i-u)^ness$",
-        PEACH: r"(?i-u)^peach$",
-        PIKACHU: r"(?i-u)^pika(chu)?$",
-        ICE_CLIMBERS: r"(?i-u)^ic(|s|ies|e[ _]?climbers)$",
-        JIGGLYPUFF: r"(?i-u)^(jiggly)?puff|jiggs$",
-        SAMUS: r"(?i-u)^samus$",
-        YOSHI: r"(?i-u)^yoshi$",
-        ZELDA: r"(?i-u)^zelda$",
-        SHEIK: r"(?i-u)^sheik$",
-        FALCO: r"(?i-u)^falco$",
-        YOUNG_LINK: r"(?i-u)^(y\.?|young)[ _]?(l|link$",
-        DR_MARIO: r"(?i-u)^doc|dr\.?[ _]?mario$",
-        ROY: r"(?i-u)^roy$",
-        PICHU: r"(?i-u)^pichu$",
-        GANONDORF: r"(?i-u)^ganon(dorf)?$",
-        MASTER_HAND: r"(?i-u)^master[ _]?hand$",
-        WIRE_FRAME_MALE: r"(?i-u)^male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male$",
-        WIRE_FRAME_FEMALE: r"(?i-u)^female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female$",
-        GIGA_BOWSER: r"(?i-u)^giga[ _]?bowser$",
-        CRAZY_HAND: r"(?i-u)^crazy[ _]?hand$",
-        SANDBAG: r"(?i-u)^sandbag$",
-        POPO: r"(?i-u)^popo$",
-    });
 }
 
 pub mod internal {

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -5,207 +5,207 @@ pub mod external {
     #[derive(Clone, Debug)]
     pub struct Info {
         pub external: External,
-        pub short: &'static str,
-        pub long: &'static str,
+        pub short_name: &'static str,
+        pub long_name: &'static str,
     }
 
     info!(External => Info {
         CAPTAIN_FALCON {
             external: External::CAPTAIN_FALCON,
-            short: "Falcon",
-            long: "Captain Falcon",
+            short_name: "Falcon",
+            long_name: "Captain Falcon",
         };
 
         DONKEY_KONG {
             external: External::DONKEY_KONG,
-            short: "DK",
-            long: "Donkey Kong",
+            short_name: "DK",
+            long_name: "Donkey Kong",
         };
 
         FOX {
             external: External::FOX,
-            short: "Fox",
-            long: "Fox",
+            short_name: "Fox",
+            long_name: "Fox",
         };
 
         GAME_AND_WATCH {
             external: External::GAME_AND_WATCH,
-            short: "G&W",
-            long: "Game and Watch",
+            short_name: "G&W",
+            long_name: "Game and Watch",
         };
 
         KIRBY {
             external: External::KIRBY,
-            short: "Kirby",
-            long: "Kirby",
+            short_name: "Kirby",
+            long_name: "Kirby",
         };
 
         BOWSER {
             external: External::BOWSER,
-            short: "Bowser",
-            long: "Bowser",
+            short_name: "Bowser",
+            long_name: "Bowser",
         };
 
         LINK {
             external: External::LINK,
-            short: "Link",
-            long: "Link",
+            short_name: "Link",
+            long_name: "Link",
         };
 
         LUIGI {
             external: External::LUIGI,
-            short: "Luigi",
-            long: "Luigi",
+            short_name: "Luigi",
+            long_name: "Luigi",
         };
 
         MARIO {
             external: External::MARIO,
-            short: "Mario",
-            long: "Mario",
+            short_name: "Mario",
+            long_name: "Mario",
         };
 
         MARTH {
             external: External::MARTH,
-            short: "Marth",
-            long: "Marth",
+            short_name: "Marth",
+            long_name: "Marth",
         };
 
         MEWTWO {
             external: External::MEWTWO,
-            short: "Mewtwo",
-            long: "Mewtwo",
+            short_name: "Mewtwo",
+            long_name: "Mewtwo",
         };
 
         NESS {
             external: External::NESS,
-            short: "Ness",
-            long: "Ness",
+            short_name: "Ness",
+            long_name: "Ness",
         };
 
         PEACH {
             external: External::PEACH,
-            short: "Peach",
-            long: "Peach",
+            short_name: "Peach",
+            long_name: "Peach",
         };
 
         PIKACHU {
             external: External::PIKACHU,
-            short: "Pika",
-            long: "Pikachu",
+            short_name: "Pika",
+            long_name: "Pikachu",
         };
 
         ICE_CLIMBERS {
             external: External::ICE_CLIMBERS,
-            short: "ICs",
-            long: "Ice Climbers",
+            short_name: "ICs",
+            long_name: "Ice Climbers",
         };
 
         JIGGLYPUFF {
             external: External::JIGGLYPUFF,
-            short: "Puff",
-            long: "Jigglypuff",
+            short_name: "Puff",
+            long_name: "Jigglypuff",
         };
 
         SAMUS {
             external: External::SAMUS,
-            short: "Samus",
-            long: "Samus",
+            short_name: "Samus",
+            long_name: "Samus",
         };
 
         YOSHI {
             external: External::YOSHI,
-            short: "Yoshi",
-            long: "Yoshi",
+            short_name: "Yoshi",
+            long_name: "Yoshi",
         };
 
         ZELDA {
             external: External::ZELDA,
-            short: "Zelda",
-            long: "Zelda",
+            short_name: "Zelda",
+            long_name: "Zelda",
         };
 
         SHEIK {
             external: External::SHEIK,
-            short: "Sheik",
-            long: "Sheik",
+            short_name: "Sheik",
+            long_name: "Sheik",
         };
 
         FALCO {
             external: External::FALCO,
-            short: "Falco",
-            long: "Falco",
+            short_name: "Falco",
+            long_name: "Falco",
         };
 
         YOUNG_LINK {
             external: External::YOUNG_LINK,
-            short: "YL",
-            long: "Young Link",
+            short_name: "YL",
+            long_name: "Young Link",
         };
 
         DR_MARIO {
             external: External::DR_MARIO,
-            short: "Doc",
-            long: "Dr. Mario",
+            short_name: "Doc",
+            long_name: "Dr. Mario",
         };
 
         ROY {
             external: External::ROY,
-            short: "Roy",
-            long: "Roy",
+            short_name: "Roy",
+            long_name: "Roy",
         };
 
         PICHU {
             external: External::PICHU,
-            short: "Pichu",
-            long: "Pichu",
+            short_name: "Pichu",
+            long_name: "Pichu",
         };
 
         GANONDORF {
             external: External::GANONDORF,
-            short: "Ganon",
-            long: "Ganondorf",
+            short_name: "Ganon",
+            long_name: "Ganondorf",
         };
 
         MASTER_HAND {
             external: External::MASTER_HAND,
-            short: "Master Hand",
-            long: "Master Hand",
+            short_name: "Master Hand",
+            long_name: "Master Hand",
         };
 
         WIRE_FRAME_MALE {
             external: External::WIRE_FRAME_MALE,
-            short: "Male Wireframe",
-            long: "Male Wireframe",
+            short_name: "Male Wireframe",
+            long_name: "Male Wireframe",
         };
 
         WIRE_FRAME_FEMALE {
             external: External::WIRE_FRAME_FEMALE,
-            short: "Female Wireframe",
-            long: "Female Wireframe",
+            short_name: "Female Wireframe",
+            long_name: "Female Wireframe",
         };
 
         GIGA_BOWSER {
             external: External::GIGA_BOWSER,
-            short: "Giga Bowser",
-            long: "Giga Bowser",
+            short_name: "Giga Bowser",
+            long_name: "Giga Bowser",
         };
 
         CRAZY_HAND {
             external: External::CRAZY_HAND,
-            short: "Crazy Hand",
-            long: "Crazy Hand",
+            short_name: "Crazy Hand",
+            long_name: "Crazy Hand",
         };
 
         SANDBAG {
             external: External::SANDBAG,
-            short: "Sandbag",
-            long: "Sandbag",
+            short_name: "Sandbag",
+            long_name: "Sandbag",
         };
 
         POPO {
             external: External::POPO,
-            short: "Popo",
-            long: "Popo",
+            short_name: "Popo",
+            long_name: "Popo",
         };
     });
 }

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -256,6 +256,7 @@ pub mod internal {
         pub internal: Internal,
         pub jumpsquat: u8,
         pub empty_landing_lag: u8,
+        pub can_walljump: bool,
     }
 
     info!(Internal => Info {
@@ -263,180 +264,210 @@ pub mod internal {
             internal: Internal::MARIO,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: true,
         };
 
         FOX {
             internal: Internal::FOX,
             jumpsquat: 3,
             empty_landing_lag: 4,
+            can_walljump: true,
         };
 
         CAPTAIN_FALCON {
             internal: Internal::CAPTAIN_FALCON,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: true,
         };
 
         DONKEY_KONG {
             internal: Internal::DONKEY_KONG,
             jumpsquat: 5,
             empty_landing_lag: 5,
+            can_walljump: false,
         };
 
         KIRBY {
             internal: Internal::KIRBY,
             jumpsquat: 3,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         BOWSER {
             internal: Internal::BOWSER,
             jumpsquat: 8,
             empty_landing_lag: 6,
+            can_walljump: false,
         };
 
         LINK {
             internal: Internal::LINK,
             jumpsquat: 6,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         SHEIK {
             internal: Internal::SHEIK,
             jumpsquat: 3,
             empty_landing_lag: 4,
+            can_walljump: true,
         };
 
         NESS {
             internal: Internal::NESS,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         PEACH {
             internal: Internal::PEACH,
             jumpsquat: 5,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         POPO {
             internal: Internal::POPO,
             jumpsquat: 3,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         NANA {
             internal: Internal::NANA,
             jumpsquat: 3,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         PIKACHU {
             internal: Internal::PIKACHU,
             jumpsquat: 3,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         SAMUS {
             internal: Internal::SAMUS,
             jumpsquat: 3,
             empty_landing_lag: 4,
+            can_walljump: true,
         };
 
         YOSHI {
             internal: Internal::YOSHI,
             jumpsquat: 5,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         JIGGLYPUFF {
             internal: Internal::JIGGLYPUFF,
             jumpsquat: 5,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         MEWTWO {
             internal: Internal::MEWTWO,
             jumpsquat: 5,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         LUIGI {
             internal: Internal::LUIGI,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         MARTH {
             internal: Internal::MARTH,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         ZELDA {
             internal: Internal::ZELDA,
             jumpsquat: 6,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         YOUNG_LINK {
             internal: Internal::YOUNG_LINK,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: true,
         };
 
         DR_MARIO {
             internal: Internal::DR_MARIO,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         FALCO {
             internal: Internal::FALCO,
             jumpsquat: 5,
             empty_landing_lag: 4,
+            can_walljump: true,
         };
 
         PICHU {
             internal: Internal::PICHU,
             jumpsquat: 3,
             empty_landing_lag: 2,
+            can_walljump: true,
         };
 
         GAME_AND_WATCH {
             internal: Internal::GAME_AND_WATCH,
             jumpsquat: 4,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         GANONDORF {
             internal: Internal::GANONDORF,
             jumpsquat: 6,
             empty_landing_lag: 5,
+            can_walljump: false,
         };
 
         ROY {
             internal: Internal::ROY,
             jumpsquat: 5,
             empty_landing_lag: 4,
+            can_walljump: false,
         };
 
         WIRE_FRAME_MALE {
             internal: Internal::WIRE_FRAME_MALE,
             jumpsquat: 7,
             empty_landing_lag: 15,
+            can_walljump: false,
         };
 
         WIRE_FRAME_FEMALE {
             internal: Internal::WIRE_FRAME_FEMALE,
             jumpsquat: 7,
             empty_landing_lag: 15,
+            can_walljump: false,
         };
 
         GIGA_BOWSER {
             internal: Internal::GIGA_BOWSER,
             jumpsquat: 6,
             empty_landing_lag: 30,
+            can_walljump: false,
         };
     });
 }

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -9,13 +9,31 @@ pub struct Info {
 	pub traction: f32,
 }
 
-macro_rules! char_info {
-	($info: ident {
+macro_rules! info {
+	($type: ident => $info: ident {
 		$($name: ident {
-			regex: $regex: expr,
-			$( $field: ident : $value: expr ),* $(,)?
-		});* $(;)?
+			$( $field: ident : $value: expr ),+ $(,)?
+		});+ $(;)?
 	}) => {
+		impl $info {
+			pub fn try_from(external: $type) -> Option<$info> {
+				match external {
+					$( $type::$name => Some($name), )*
+					_ => None
+				}
+			}
+		}
+
+		$(pub const $name: $info = $info {
+			$( $field: $value ),*
+		};)*
+	}
+}
+
+macro_rules! info_regex {
+	($info: ident {
+        $($name: ident : $regex: expr),+ $(,)?
+    }) => {
 		mod regexes {
 			use lazy_static::lazy_static;
 			use regex::Regex;
@@ -25,13 +43,6 @@ macro_rules! char_info {
 		}
 
 		impl $info {
-			pub fn try_from(external: External) -> Option<$info> {
-				match external {
-					$( External::$name => Some($name), )*
-					_ => None
-				}
-			}
-
 			pub fn try_match(s: &str) -> Option<$info> {
 				match s {
 					$( s if regexes::$name.is_match(s) => Some($name), )*
@@ -39,244 +50,274 @@ macro_rules! char_info {
 				}
 			}
 		}
-
-		$(pub const $name: $info = $info {
-			external: External::$name,
-			$( $field: $value ),*
-		};)*
 	}
 }
 
-
-char_info!(Info {
+info!(External => Info {
 	CAPTAIN_FALCON {
-		regex: r"(?i-u)^(capt(ain|\.)?[ _]?)?falcon$",
+        external: External::CAPTAIN_FALCON,
 		short: "Falcon",
 		long: "Captain Falcon",
 		traction: 0.08,
 	};
 
 	DONKEY_KONG {
-		regex: r"(?i-u)^dk|(donkey[ _]?kong$",
+        external: External::DONKEY_KONG,
 		short: "DK",
 		long: "Donkey Kong",
 		traction: 0.08,
 	};
 
 	FOX {
-		regex: r"(?i-u)^fox$",
+        external: External::FOX,
 		short: "Fox",
 		long: "Fox",
 		traction: 0.08,
 	};
 
 	GAME_AND_WATCH {
-		regex: r"(?i-u)^(g|game)[ _]?(and|&|n)[ _]?(w|watch)$",
+        external: External::GAME_AND_WATCH,
 		short: "G&W",
 		long: "Game and Watch",
 		traction: 0.06,
 	};
 
 	KIRBY {
-		regex: r"(?i-u)^kirby$",
+        external: External::KIRBY,
 		short: "Kirby",
 		long: "Kirby",
 		traction: 0.08,
 	};
 
 	BOWSER {
-		regex: r"(?i-u)^bowser$",
+        external: External::BOWSER,
 		short: "Bowser",
 		long: "Bowser",
 		traction: 0.06,
 	};
 
 	LINK {
-		regex: r"(?i-u)^link$",
+        external: External::LINK,
 		short: "Link",
 		long: "Link",
 		traction: 0.1,
 	};
 
 	LUIGI {
-		regex: r"(?i-u)^luigi$",
+        external: External::LUIGI,
 		short: "Luigi",
 		long: "Luigi",
 		traction: 0.025,
 	};
 
 	MARIO {
-		regex: r"(?i-u)^mario$",
+        external: External::MARIO,
 		short: "Mario",
 		long: "Mario",
 		traction: 0.06,
 	};
 
 	MARTH {
-		regex: r"(?i-u)^marth$",
+        external: External::MARTH,
 		short: "Marth",
 		long: "Marth",
 		traction: 0.06,
 	};
 
 	MEWTWO {
-		regex: r"(?i-u)^mewtwo|mew2|m2$",
+        external: External::MEWTWO,
 		short: "Mewtwo",
 		long: "Mewtwo",
 		traction: 0.04,
 	};
 
 	NESS {
-		regex: r"(?i-u)^ness$",
+        external: External::NESS,
 		short: "Ness",
 		long: "Ness",
 		traction: 0.06,
 	};
 
 	PEACH {
-		regex: r"(?i-u)^peach$",
+        external: External::PEACH,
 		short: "Peach",
 		long: "Peach",
 		traction: 0.1,
 	};
 
 	PIKACHU {
-		regex: r"(?i-u)^pika(chu)?$",
+        external: External::PIKACHU,
 		short: "Pika",
 		long: "Pikachu",
 		traction: 0.09,
 	};
 
 	ICE_CLIMBERS {
-		regex: r"(?i-u)^ic(|s|ies|e[ _]?climbers)$",
+        external: External::ICE_CLIMBERS,
 		short: "ICs",
 		long: "Ice Climbers",
 		traction: 0.035,
 	};
 
 	JIGGLYPUFF {
-		regex: r"(?i-u)^(jiggly)?puff|jiggs$",
+        external: External::JIGGLYPUFF,
 		short: "Puff",
 		long: "Jigglypuff",
 		traction: 0.09,
 	};
 
 	SAMUS {
-		regex: r"(?i-u)^samus$",
+        external: External::SAMUS,
 		short: "Samus",
 		long: "Samus",
 		traction: 0.06,
 	};
 
 	YOSHI {
-		regex: r"(?i-u)^yoshi$",
+        external: External::YOSHI,
 		short: "Yoshi",
 		long: "Yoshi",
 		traction: 0.06,
 	};
 
 	ZELDA {
-		regex: r"(?i-u)^zelda$",
+        external: External::ZELDA,
 		short: "Zelda",
 		long: "Zelda",
 		traction: 0.1,
 	};
 
 	SHEIK {
-		regex: r"(?i-u)^sheik$",
+        external: External::SHEIK,
 		short: "Sheik",
 		long: "Sheik",
 		traction: 0.08,
 	};
 
 	FALCO {
-		regex: r"(?i-u)^falco$",
+        external: External::FALCO,
 		short: "Falco",
 		long: "Falco",
 		traction: 0.08,
 	};
 
 	YOUNG_LINK {
-		regex: r"(?i-u)^(y\.?|young)[ _]?(l|link$",
+        external: External::YOUNG_LINK,
 		short: "YL",
 		long: "Young Link",
 		traction: 0.08,
 	};
 
 	DR_MARIO {
-		regex: r"(?i-u)^doc|dr\.?[ _]?mario$",
+        external: External::DR_MARIO,
 		short: "Doc",
 		long: "Dr. Mario",
 		traction: 0.06,
 	};
 
 	ROY {
-		regex: r"(?i-u)^roy$",
+        external: External::ROY,
 		short: "Roy",
 		long: "Roy",
 		traction: 0.06,
 	};
 
 	PICHU {
-		regex: r"(?i-u)^pichu$",
+        external: External::PICHU,
 		short: "Pichu",
 		long: "Pichu",
 		traction: 0.1,
 	};
 
 	GANONDORF {
-		regex: r"(?i-u)^ganon(dorf)?$",
+        external: External::GANONDORF,
 		short: "Ganon",
 		long: "Ganondorf",
 		traction: 0.07,
 	};
 
 	MASTER_HAND {
-		regex: r"(?i-u)^master[ _]?hand$",
+        external: External::MASTER_HAND,
 		short: "Master Hand",
 		long: "Master Hand",
 		traction: 0.0,
 	};
 
 	WIRE_FRAME_MALE {
-		regex: r"(?i-u)^male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male$",
+        external: External::WIRE_FRAME_MALE,
 		short: "Male Wireframe",
 		long: "Male Wireframe",
 		traction: 0.0,
 	};
 
 	WIRE_FRAME_FEMALE {
-		regex: r"(?i-u)^female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female$",
+        external: External::WIRE_FRAME_FEMALE,
 		short: "Female Wireframe",
 		long: "Female Wireframe",
 		traction: 0.0,
 	};
 
 	GIGA_BOWSER {
-		regex: r"(?i-u)^giga[ _]?bowser$",
+        external: External::GIGA_BOWSER,
 		short: "Giga Bowser",
 		long: "Giga Bowser",
 		traction: 0.0,
 	};
 
 	CRAZY_HAND {
-		regex: r"(?i-u)^crazy[ _]?hand$",
+        external: External::CRAZY_HAND,
 		short: "Crazy Hand",
 		long: "Crazy Hand",
 		traction: 0.0,
 	};
 
 	SANDBAG {
-		regex: r"(?i-u)^sandbag$",
+        external: External::SANDBAG,
 		short: "Sandbag",
 		long: "Sandbag",
 		traction: 0.0,
 	};
 
 	POPO {
-		regex: r"(?i-u)^popo$",
+        external: External::POPO,
 		short: "Popo",
 		long: "Popo",
 		traction: 0.035,
 	};
+});
+
+info_regex!(Info {
+    CAPTAIN_FALCON: r"(?i-u)^(capt(ain|\.)?[ _]?)?falcon$",
+    DONKEY_KONG: r"(?i-u)^dk|(donkey[ _]?kong$",
+    FOX: r"(?i-u)^fox$",
+    GAME_AND_WATCH: r"(?i-u)^(g|game)[ _]?(and|&|n)[ _]?(w|watch)$",
+    KIRBY: r"(?i-u)^kirby$",
+    BOWSER: r"(?i-u)^bowser$",
+    LINK: r"(?i-u)^link$",
+    LUIGI: r"(?i-u)^luigi$",
+    MARIO: r"(?i-u)^mario$",
+    MARTH: r"(?i-u)^marth$",
+    MEWTWO: r"(?i-u)^mewtwo|mew2|m2$",
+    NESS: r"(?i-u)^ness$",
+    PEACH: r"(?i-u)^peach$",
+    PIKACHU: r"(?i-u)^pika(chu)?$",
+    ICE_CLIMBERS: r"(?i-u)^ic(|s|ies|e[ _]?climbers)$",
+    JIGGLYPUFF: r"(?i-u)^(jiggly)?puff|jiggs$",
+    SAMUS: r"(?i-u)^samus$",
+    YOSHI: r"(?i-u)^yoshi$",
+    ZELDA: r"(?i-u)^zelda$",
+    SHEIK: r"(?i-u)^sheik$",
+    FALCO: r"(?i-u)^falco$",
+    YOUNG_LINK: r"(?i-u)^(y\.?|young)[ _]?(l|link$",
+    DR_MARIO: r"(?i-u)^doc|dr\.?[ _]?mario$",
+    ROY: r"(?i-u)^roy$",
+    PICHU: r"(?i-u)^pichu$",
+    GANONDORF: r"(?i-u)^ganon(dorf)?$",
+    MASTER_HAND: r"(?i-u)^master[ _]?hand$",
+    WIRE_FRAME_MALE: r"(?i-u)^male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male$",
+    WIRE_FRAME_FEMALE: r"(?i-u)^female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female$",
+    GIGA_BOWSER: r"(?i-u)^giga[ _]?bowser$",
+    CRAZY_HAND: r"(?i-u)^crazy[ _]?hand$",
+    SANDBAG: r"(?i-u)^sandbag$",
+    POPO: r"(?i-u)^popo$",
 });

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -49,231 +49,231 @@ macro_rules! char_info {
 
 char_info!(Info {
 	CAPTAIN_FALCON {
-		regex: r"(?i-u)(capt(ain|\.)?[ _]?)?falcon",
+		regex: r"(?i-u)^(capt(ain|\.)?[ _]?)?falcon$",
 		short: "Falcon",
 		long: "Captain Falcon",
 		traction: 0.08,
 	};
 
 	DONKEY_KONG {
-		regex: r"(?i-u)dk|(donkey[ _]?kong",
+		regex: r"(?i-u)^dk|(donkey[ _]?kong$",
 		short: "DK",
 		long: "Donkey Kong",
 		traction: 0.08,
 	};
 
 	FOX {
-		regex: r"(?i-u)fox",
+		regex: r"(?i-u)^fox$",
 		short: "Fox",
 		long: "Fox",
 		traction: 0.08,
 	};
 
 	GAME_AND_WATCH {
-		regex: r"(?i-u)(g|game)[ _]?(and|&|n)[ _]?(w|watch)",
+		regex: r"(?i-u)^(g|game)[ _]?(and|&|n)[ _]?(w|watch)$",
 		short: "G&W",
 		long: "Game and Watch",
 		traction: 0.06,
 	};
 
 	KIRBY {
-		regex: r"(?i-u)kirby",
+		regex: r"(?i-u)^kirby$",
 		short: "Kirby",
 		long: "Kirby",
 		traction: 0.08,
 	};
 
 	BOWSER {
-		regex: r"(?i-u)bowser",
+		regex: r"(?i-u)^bowser$",
 		short: "Bowser",
 		long: "Bowser",
 		traction: 0.06,
 	};
 
 	LINK {
-		regex: r"(?i-u)link",
+		regex: r"(?i-u)^link$",
 		short: "Link",
 		long: "Link",
 		traction: 0.1,
 	};
 
 	LUIGI {
-		regex: r"(?i-u)luigi",
+		regex: r"(?i-u)^luigi$",
 		short: "Luigi",
 		long: "Luigi",
 		traction: 0.025,
 	};
 
 	MARIO {
-		regex: r"(?i-u)mario",
+		regex: r"(?i-u)^mario$",
 		short: "Mario",
 		long: "Mario",
 		traction: 0.06,
 	};
 
 	MARTH {
-		regex: r"(?i-u)marth",
+		regex: r"(?i-u)^marth$",
 		short: "Marth",
 		long: "Marth",
 		traction: 0.06,
 	};
 
 	MEWTWO {
-		regex: r"(?i-u)mewtwo|mew2|m2",
+		regex: r"(?i-u)^mewtwo|mew2|m2$",
 		short: "Mewtwo",
 		long: "Mewtwo",
 		traction: 0.04,
 	};
 
 	NESS {
-		regex: r"(?i-u)ness",
+		regex: r"(?i-u)^ness$",
 		short: "Ness",
 		long: "Ness",
 		traction: 0.06,
 	};
 
 	PEACH {
-		regex: r"(?i-u)peach",
+		regex: r"(?i-u)^peach$",
 		short: "Peach",
 		long: "Peach",
 		traction: 0.1,
 	};
 
 	PIKACHU {
-		regex: r"(?i-u)pika(chu)?",
+		regex: r"(?i-u)^pika(chu)?$",
 		short: "Pika",
 		long: "Pikachu",
 		traction: 0.09,
 	};
 
 	ICE_CLIMBERS {
-		regex: r"(?i-u)ic(|s|ies|e[ _]?climbers)",
+		regex: r"(?i-u)^ic(|s|ies|e[ _]?climbers)$",
 		short: "ICs",
 		long: "Ice Climbers",
 		traction: 0.035,
 	};
 
 	JIGGLYPUFF {
-		regex: r"(?i-u)(jiggly)?puff|jiggs",
+		regex: r"(?i-u)^(jiggly)?puff|jiggs$",
 		short: "Puff",
 		long: "Jigglypuff",
 		traction: 0.09,
 	};
 
 	SAMUS {
-		regex: r"(?i-u)samus",
+		regex: r"(?i-u)^samus$",
 		short: "Samus",
 		long: "Samus",
 		traction: 0.06,
 	};
 
 	YOSHI {
-		regex: r"(?i-u)yoshi",
+		regex: r"(?i-u)^yoshi$",
 		short: "Yoshi",
 		long: "Yoshi",
 		traction: 0.06,
 	};
 
 	ZELDA {
-		regex: r"(?i-u)zelda",
+		regex: r"(?i-u)^zelda$",
 		short: "Zelda",
 		long: "Zelda",
 		traction: 0.1,
 	};
 
 	SHEIK {
-		regex: r"(?i-u)sheik",
+		regex: r"(?i-u)^sheik$",
 		short: "Sheik",
 		long: "Sheik",
 		traction: 0.08,
 	};
 
 	FALCO {
-		regex: r"(?i-u)falco",
+		regex: r"(?i-u)^falco$",
 		short: "Falco",
 		long: "Falco",
 		traction: 0.08,
 	};
 
 	YOUNG_LINK {
-		regex: r"(?i-u)(y\.?|young)[ _]?(l|link",
+		regex: r"(?i-u)^(y\.?|young)[ _]?(l|link$",
 		short: "YL",
 		long: "Young Link",
 		traction: 0.08,
 	};
 
 	DR_MARIO {
-		regex: r"(?i-u)doc|dr\.?[ _]?mario",
+		regex: r"(?i-u)^doc|dr\.?[ _]?mario$",
 		short: "Doc",
 		long: "Dr. Mario",
 		traction: 0.06,
 	};
 
 	ROY {
-		regex: r"(?i-u)roy",
+		regex: r"(?i-u)^roy$",
 		short: "Roy",
 		long: "Roy",
 		traction: 0.06,
 	};
 
 	PICHU {
-		regex: r"(?i-u)pichu",
+		regex: r"(?i-u)^pichu$",
 		short: "Pichu",
 		long: "Pichu",
 		traction: 0.1,
 	};
 
 	GANONDORF {
-		regex: r"(?i-u)ganon(dorf)?",
+		regex: r"(?i-u)^ganon(dorf)?$",
 		short: "Ganon",
 		long: "Ganondorf",
 		traction: 0.07,
 	};
 
 	MASTER_HAND {
-		regex: r"(?i-u)master[ _]?hand",
+		regex: r"(?i-u)^master[ _]?hand$",
 		short: "Master Hand",
 		long: "Master Hand",
 		traction: 0.0,
 	};
 
 	WIRE_FRAME_MALE {
-		regex: r"(?i-u)male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male",
+		regex: r"(?i-u)^male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male$",
 		short: "Male Wireframe",
 		long: "Male Wireframe",
 		traction: 0.0,
 	};
 
 	WIRE_FRAME_FEMALE {
-		regex: r"(?i-u)female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female",
+		regex: r"(?i-u)^female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female$",
 		short: "Female Wireframe",
 		long: "Female Wireframe",
 		traction: 0.0,
 	};
 
 	GIGA_BOWSER {
-		regex: r"(?i-u)giga[ _]?bowser",
+		regex: r"(?i-u)^giga[ _]?bowser$",
 		short: "Giga Bowser",
 		long: "Giga Bowser",
 		traction: 0.0,
 	};
 
 	CRAZY_HAND {
-		regex: r"(?i-u)crazy[ _]?hand",
+		regex: r"(?i-u)^crazy[ _]?hand$",
 		short: "Crazy Hand",
 		long: "Crazy Hand",
 		traction: 0.0,
 	};
 
 	SANDBAG {
-		regex: r"(?i-u)sandbag",
+		regex: r"(?i-u)^sandbag$",
 		short: "Sandbag",
 		long: "Sandbag",
 		traction: 0.0,
 	};
 
 	POPO {
-		regex: r"(?i-u)popo",
+		regex: r"(?i-u)^popo$",
 		short: "Popo",
 		long: "Popo",
 		traction: 0.035,

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -1,5 +1,6 @@
 use crate::model::enums::character::External;
 
+#[non_exhaustive]
 #[derive(Clone)]
 pub struct Info {
 	pub external: External,

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -1,323 +1,442 @@
-use crate::model::enums::character::External;
+pub mod external {
+    use crate::model::enums::character::External;
 
-#[non_exhaustive]
-#[derive(Clone)]
-pub struct Info {
-	pub external: External,
-	pub short: &'static str,
-	pub long: &'static str,
-	pub traction: f32,
+    #[non_exhaustive]
+    #[derive(Clone, Debug)]
+    pub struct Info {
+        pub external: External,
+        pub short: &'static str,
+        pub long: &'static str,
+    }
+
+    info!(External => Info {
+        CAPTAIN_FALCON {
+            external: External::CAPTAIN_FALCON,
+            short: "Falcon",
+            long: "Captain Falcon",
+        };
+
+        DONKEY_KONG {
+            external: External::DONKEY_KONG,
+            short: "DK",
+            long: "Donkey Kong",
+        };
+
+        FOX {
+            external: External::FOX,
+            short: "Fox",
+            long: "Fox",
+        };
+
+        GAME_AND_WATCH {
+            external: External::GAME_AND_WATCH,
+            short: "G&W",
+            long: "Game and Watch",
+        };
+
+        KIRBY {
+            external: External::KIRBY,
+            short: "Kirby",
+            long: "Kirby",
+        };
+
+        BOWSER {
+            external: External::BOWSER,
+            short: "Bowser",
+            long: "Bowser",
+        };
+
+        LINK {
+            external: External::LINK,
+            short: "Link",
+            long: "Link",
+        };
+
+        LUIGI {
+            external: External::LUIGI,
+            short: "Luigi",
+            long: "Luigi",
+        };
+
+        MARIO {
+            external: External::MARIO,
+            short: "Mario",
+            long: "Mario",
+        };
+
+        MARTH {
+            external: External::MARTH,
+            short: "Marth",
+            long: "Marth",
+        };
+
+        MEWTWO {
+            external: External::MEWTWO,
+            short: "Mewtwo",
+            long: "Mewtwo",
+        };
+
+        NESS {
+            external: External::NESS,
+            short: "Ness",
+            long: "Ness",
+        };
+
+        PEACH {
+            external: External::PEACH,
+            short: "Peach",
+            long: "Peach",
+        };
+
+        PIKACHU {
+            external: External::PIKACHU,
+            short: "Pika",
+            long: "Pikachu",
+        };
+
+        ICE_CLIMBERS {
+            external: External::ICE_CLIMBERS,
+            short: "ICs",
+            long: "Ice Climbers",
+        };
+
+        JIGGLYPUFF {
+            external: External::JIGGLYPUFF,
+            short: "Puff",
+            long: "Jigglypuff",
+        };
+
+        SAMUS {
+            external: External::SAMUS,
+            short: "Samus",
+            long: "Samus",
+        };
+
+        YOSHI {
+            external: External::YOSHI,
+            short: "Yoshi",
+            long: "Yoshi",
+        };
+
+        ZELDA {
+            external: External::ZELDA,
+            short: "Zelda",
+            long: "Zelda",
+        };
+
+        SHEIK {
+            external: External::SHEIK,
+            short: "Sheik",
+            long: "Sheik",
+        };
+
+        FALCO {
+            external: External::FALCO,
+            short: "Falco",
+            long: "Falco",
+        };
+
+        YOUNG_LINK {
+            external: External::YOUNG_LINK,
+            short: "YL",
+            long: "Young Link",
+        };
+
+        DR_MARIO {
+            external: External::DR_MARIO,
+            short: "Doc",
+            long: "Dr. Mario",
+        };
+
+        ROY {
+            external: External::ROY,
+            short: "Roy",
+            long: "Roy",
+        };
+
+        PICHU {
+            external: External::PICHU,
+            short: "Pichu",
+            long: "Pichu",
+        };
+
+        GANONDORF {
+            external: External::GANONDORF,
+            short: "Ganon",
+            long: "Ganondorf",
+        };
+
+        MASTER_HAND {
+            external: External::MASTER_HAND,
+            short: "Master Hand",
+            long: "Master Hand",
+        };
+
+        WIRE_FRAME_MALE {
+            external: External::WIRE_FRAME_MALE,
+            short: "Male Wireframe",
+            long: "Male Wireframe",
+        };
+
+        WIRE_FRAME_FEMALE {
+            external: External::WIRE_FRAME_FEMALE,
+            short: "Female Wireframe",
+            long: "Female Wireframe",
+        };
+
+        GIGA_BOWSER {
+            external: External::GIGA_BOWSER,
+            short: "Giga Bowser",
+            long: "Giga Bowser",
+        };
+
+        CRAZY_HAND {
+            external: External::CRAZY_HAND,
+            short: "Crazy Hand",
+            long: "Crazy Hand",
+        };
+
+        SANDBAG {
+            external: External::SANDBAG,
+            short: "Sandbag",
+            long: "Sandbag",
+        };
+
+        POPO {
+            external: External::POPO,
+            short: "Popo",
+            long: "Popo",
+        };
+    });
+
+
+    info_regex!(Info {
+        CAPTAIN_FALCON: r"(?i-u)^(capt(ain|\.)?[ _]?)?falcon$",
+        DONKEY_KONG: r"(?i-u)^dk|(donkey[ _]?kong$",
+        FOX: r"(?i-u)^fox$",
+        GAME_AND_WATCH: r"(?i-u)^(g|game)[ _]?(and|&|n)[ _]?(w|watch)$",
+        KIRBY: r"(?i-u)^kirby$",
+        BOWSER: r"(?i-u)^bowser$",
+        LINK: r"(?i-u)^link$",
+        LUIGI: r"(?i-u)^luigi$",
+        MARIO: r"(?i-u)^mario$",
+        MARTH: r"(?i-u)^marth$",
+        MEWTWO: r"(?i-u)^mewtwo|mew2|m2$",
+        NESS: r"(?i-u)^ness$",
+        PEACH: r"(?i-u)^peach$",
+        PIKACHU: r"(?i-u)^pika(chu)?$",
+        ICE_CLIMBERS: r"(?i-u)^ic(|s|ies|e[ _]?climbers)$",
+        JIGGLYPUFF: r"(?i-u)^(jiggly)?puff|jiggs$",
+        SAMUS: r"(?i-u)^samus$",
+        YOSHI: r"(?i-u)^yoshi$",
+        ZELDA: r"(?i-u)^zelda$",
+        SHEIK: r"(?i-u)^sheik$",
+        FALCO: r"(?i-u)^falco$",
+        YOUNG_LINK: r"(?i-u)^(y\.?|young)[ _]?(l|link$",
+        DR_MARIO: r"(?i-u)^doc|dr\.?[ _]?mario$",
+        ROY: r"(?i-u)^roy$",
+        PICHU: r"(?i-u)^pichu$",
+        GANONDORF: r"(?i-u)^ganon(dorf)?$",
+        MASTER_HAND: r"(?i-u)^master[ _]?hand$",
+        WIRE_FRAME_MALE: r"(?i-u)^male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male$",
+        WIRE_FRAME_FEMALE: r"(?i-u)^female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female$",
+        GIGA_BOWSER: r"(?i-u)^giga[ _]?bowser$",
+        CRAZY_HAND: r"(?i-u)^crazy[ _]?hand$",
+        SANDBAG: r"(?i-u)^sandbag$",
+        POPO: r"(?i-u)^popo$",
+    });
 }
 
-macro_rules! info {
-	($type: ident => $info: ident {
-		$($name: ident {
-			$( $field: ident : $value: expr ),+ $(,)?
-		});+ $(;)?
-	}) => {
-		impl $info {
-			pub fn try_from(external: $type) -> Option<$info> {
-				match external {
-					$( $type::$name => Some($name), )*
-					_ => None
-				}
-			}
-		}
+pub mod internal {
+    use crate::model::enums::character::Internal;
 
-		$(pub const $name: $info = $info {
-			$( $field: $value ),*
-		};)*
-	}
+    #[non_exhaustive]
+    #[derive(Clone, Debug)]
+    pub struct Info {
+        pub internal: Internal,
+        pub jumpsquat: u8,
+        pub empty_landing_lag: u8,
+    }
+
+    info!(Internal => Info {
+        MARIO {
+            internal: Internal::MARIO,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        FOX {
+            internal: Internal::FOX,
+            jumpsquat: 3,
+            empty_landing_lag: 4,
+        };
+
+        CAPTAIN_FALCON {
+            internal: Internal::CAPTAIN_FALCON,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        DONKEY_KONG {
+            internal: Internal::DONKEY_KONG,
+            jumpsquat: 5,
+            empty_landing_lag: 5,
+        };
+
+        KIRBY {
+            internal: Internal::KIRBY,
+            jumpsquat: 3,
+            empty_landing_lag: 4,
+        };
+
+        BOWSER {
+            internal: Internal::BOWSER,
+            jumpsquat: 8,
+            empty_landing_lag: 6,
+        };
+
+        LINK {
+            internal: Internal::LINK,
+            jumpsquat: 6,
+            empty_landing_lag: 4,
+        };
+
+        SHEIK {
+            internal: Internal::SHEIK,
+            jumpsquat: 3,
+            empty_landing_lag: 4,
+        };
+
+        NESS {
+            internal: Internal::NESS,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        PEACH {
+            internal: Internal::PEACH,
+            jumpsquat: 5,
+            empty_landing_lag: 4,
+        };
+
+        POPO {
+            internal: Internal::POPO,
+            jumpsquat: 3,
+            empty_landing_lag: 4,
+        };
+
+        NANA {
+            internal: Internal::NANA,
+            jumpsquat: 3,
+            empty_landing_lag: 4,
+        };
+
+        PIKACHU {
+            internal: Internal::PIKACHU,
+            jumpsquat: 3,
+            empty_landing_lag: 4,
+        };
+
+        SAMUS {
+            internal: Internal::SAMUS,
+            jumpsquat: 3,
+            empty_landing_lag: 4,
+        };
+
+        YOSHI {
+            internal: Internal::YOSHI,
+            jumpsquat: 5,
+            empty_landing_lag: 4,
+        };
+
+        JIGGLYPUFF {
+            internal: Internal::JIGGLYPUFF,
+            jumpsquat: 5,
+            empty_landing_lag: 4,
+        };
+
+        MEWTWO {
+            internal: Internal::MEWTWO,
+            jumpsquat: 5,
+            empty_landing_lag: 4,
+        };
+
+        LUIGI {
+            internal: Internal::LUIGI,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        MARTH {
+            internal: Internal::MARTH,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        ZELDA {
+            internal: Internal::ZELDA,
+            jumpsquat: 6,
+            empty_landing_lag: 4,
+        };
+
+        YOUNG_LINK {
+            internal: Internal::YOUNG_LINK,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        DR_MARIO {
+            internal: Internal::DR_MARIO,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        FALCO {
+            internal: Internal::FALCO,
+            jumpsquat: 5,
+            empty_landing_lag: 4,
+        };
+
+        PICHU {
+            internal: Internal::PICHU,
+            jumpsquat: 3,
+            empty_landing_lag: 2,
+        };
+
+        GAME_AND_WATCH {
+            internal: Internal::GAME_AND_WATCH,
+            jumpsquat: 4,
+            empty_landing_lag: 4,
+        };
+
+        GANONDORF {
+            internal: Internal::GANONDORF,
+            jumpsquat: 6,
+            empty_landing_lag: 5,
+        };
+
+        ROY {
+            internal: Internal::ROY,
+            jumpsquat: 5,
+            empty_landing_lag: 4,
+        };
+
+        WIRE_FRAME_MALE {
+            internal: Internal::WIRE_FRAME_MALE,
+            jumpsquat: 7,
+            empty_landing_lag: 15,
+        };
+
+        WIRE_FRAME_FEMALE {
+            internal: Internal::WIRE_FRAME_FEMALE,
+            jumpsquat: 7,
+            empty_landing_lag: 15,
+        };
+
+        GIGA_BOWSER {
+            internal: Internal::GIGA_BOWSER,
+            jumpsquat: 6,
+            empty_landing_lag: 30,
+        };
+    });
 }
-
-macro_rules! info_regex {
-	($info: ident {
-        $($name: ident : $regex: expr),+ $(,)?
-    }) => {
-		mod regexes {
-			use lazy_static::lazy_static;
-			use regex::Regex;
-			lazy_static! {
-				$( pub static ref $name: Regex = Regex::new($regex).unwrap(); )*
-			}
-		}
-
-		impl $info {
-			pub fn try_match(s: &str) -> Option<$info> {
-				match s {
-					$( s if regexes::$name.is_match(s) => Some($name), )*
-					_ => None,
-				}
-			}
-		}
-	}
-}
-
-info!(External => Info {
-	CAPTAIN_FALCON {
-        external: External::CAPTAIN_FALCON,
-		short: "Falcon",
-		long: "Captain Falcon",
-		traction: 0.08,
-	};
-
-	DONKEY_KONG {
-        external: External::DONKEY_KONG,
-		short: "DK",
-		long: "Donkey Kong",
-		traction: 0.08,
-	};
-
-	FOX {
-        external: External::FOX,
-		short: "Fox",
-		long: "Fox",
-		traction: 0.08,
-	};
-
-	GAME_AND_WATCH {
-        external: External::GAME_AND_WATCH,
-		short: "G&W",
-		long: "Game and Watch",
-		traction: 0.06,
-	};
-
-	KIRBY {
-        external: External::KIRBY,
-		short: "Kirby",
-		long: "Kirby",
-		traction: 0.08,
-	};
-
-	BOWSER {
-        external: External::BOWSER,
-		short: "Bowser",
-		long: "Bowser",
-		traction: 0.06,
-	};
-
-	LINK {
-        external: External::LINK,
-		short: "Link",
-		long: "Link",
-		traction: 0.1,
-	};
-
-	LUIGI {
-        external: External::LUIGI,
-		short: "Luigi",
-		long: "Luigi",
-		traction: 0.025,
-	};
-
-	MARIO {
-        external: External::MARIO,
-		short: "Mario",
-		long: "Mario",
-		traction: 0.06,
-	};
-
-	MARTH {
-        external: External::MARTH,
-		short: "Marth",
-		long: "Marth",
-		traction: 0.06,
-	};
-
-	MEWTWO {
-        external: External::MEWTWO,
-		short: "Mewtwo",
-		long: "Mewtwo",
-		traction: 0.04,
-	};
-
-	NESS {
-        external: External::NESS,
-		short: "Ness",
-		long: "Ness",
-		traction: 0.06,
-	};
-
-	PEACH {
-        external: External::PEACH,
-		short: "Peach",
-		long: "Peach",
-		traction: 0.1,
-	};
-
-	PIKACHU {
-        external: External::PIKACHU,
-		short: "Pika",
-		long: "Pikachu",
-		traction: 0.09,
-	};
-
-	ICE_CLIMBERS {
-        external: External::ICE_CLIMBERS,
-		short: "ICs",
-		long: "Ice Climbers",
-		traction: 0.035,
-	};
-
-	JIGGLYPUFF {
-        external: External::JIGGLYPUFF,
-		short: "Puff",
-		long: "Jigglypuff",
-		traction: 0.09,
-	};
-
-	SAMUS {
-        external: External::SAMUS,
-		short: "Samus",
-		long: "Samus",
-		traction: 0.06,
-	};
-
-	YOSHI {
-        external: External::YOSHI,
-		short: "Yoshi",
-		long: "Yoshi",
-		traction: 0.06,
-	};
-
-	ZELDA {
-        external: External::ZELDA,
-		short: "Zelda",
-		long: "Zelda",
-		traction: 0.1,
-	};
-
-	SHEIK {
-        external: External::SHEIK,
-		short: "Sheik",
-		long: "Sheik",
-		traction: 0.08,
-	};
-
-	FALCO {
-        external: External::FALCO,
-		short: "Falco",
-		long: "Falco",
-		traction: 0.08,
-	};
-
-	YOUNG_LINK {
-        external: External::YOUNG_LINK,
-		short: "YL",
-		long: "Young Link",
-		traction: 0.08,
-	};
-
-	DR_MARIO {
-        external: External::DR_MARIO,
-		short: "Doc",
-		long: "Dr. Mario",
-		traction: 0.06,
-	};
-
-	ROY {
-        external: External::ROY,
-		short: "Roy",
-		long: "Roy",
-		traction: 0.06,
-	};
-
-	PICHU {
-        external: External::PICHU,
-		short: "Pichu",
-		long: "Pichu",
-		traction: 0.1,
-	};
-
-	GANONDORF {
-        external: External::GANONDORF,
-		short: "Ganon",
-		long: "Ganondorf",
-		traction: 0.07,
-	};
-
-	MASTER_HAND {
-        external: External::MASTER_HAND,
-		short: "Master Hand",
-		long: "Master Hand",
-		traction: 0.0,
-	};
-
-	WIRE_FRAME_MALE {
-        external: External::WIRE_FRAME_MALE,
-		short: "Male Wireframe",
-		long: "Male Wireframe",
-		traction: 0.0,
-	};
-
-	WIRE_FRAME_FEMALE {
-        external: External::WIRE_FRAME_FEMALE,
-		short: "Female Wireframe",
-		long: "Female Wireframe",
-		traction: 0.0,
-	};
-
-	GIGA_BOWSER {
-        external: External::GIGA_BOWSER,
-		short: "Giga Bowser",
-		long: "Giga Bowser",
-		traction: 0.0,
-	};
-
-	CRAZY_HAND {
-        external: External::CRAZY_HAND,
-		short: "Crazy Hand",
-		long: "Crazy Hand",
-		traction: 0.0,
-	};
-
-	SANDBAG {
-        external: External::SANDBAG,
-		short: "Sandbag",
-		long: "Sandbag",
-		traction: 0.0,
-	};
-
-	POPO {
-        external: External::POPO,
-		short: "Popo",
-		long: "Popo",
-		traction: 0.035,
-	};
-});
-
-info_regex!(Info {
-    CAPTAIN_FALCON: r"(?i-u)^(capt(ain|\.)?[ _]?)?falcon$",
-    DONKEY_KONG: r"(?i-u)^dk|(donkey[ _]?kong$",
-    FOX: r"(?i-u)^fox$",
-    GAME_AND_WATCH: r"(?i-u)^(g|game)[ _]?(and|&|n)[ _]?(w|watch)$",
-    KIRBY: r"(?i-u)^kirby$",
-    BOWSER: r"(?i-u)^bowser$",
-    LINK: r"(?i-u)^link$",
-    LUIGI: r"(?i-u)^luigi$",
-    MARIO: r"(?i-u)^mario$",
-    MARTH: r"(?i-u)^marth$",
-    MEWTWO: r"(?i-u)^mewtwo|mew2|m2$",
-    NESS: r"(?i-u)^ness$",
-    PEACH: r"(?i-u)^peach$",
-    PIKACHU: r"(?i-u)^pika(chu)?$",
-    ICE_CLIMBERS: r"(?i-u)^ic(|s|ies|e[ _]?climbers)$",
-    JIGGLYPUFF: r"(?i-u)^(jiggly)?puff|jiggs$",
-    SAMUS: r"(?i-u)^samus$",
-    YOSHI: r"(?i-u)^yoshi$",
-    ZELDA: r"(?i-u)^zelda$",
-    SHEIK: r"(?i-u)^sheik$",
-    FALCO: r"(?i-u)^falco$",
-    YOUNG_LINK: r"(?i-u)^(y\.?|young)[ _]?(l|link$",
-    DR_MARIO: r"(?i-u)^doc|dr\.?[ _]?mario$",
-    ROY: r"(?i-u)^roy$",
-    PICHU: r"(?i-u)^pichu$",
-    GANONDORF: r"(?i-u)^ganon(dorf)?$",
-    MASTER_HAND: r"(?i-u)^master[ _]?hand$",
-    WIRE_FRAME_MALE: r"(?i-u)^male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male$",
-    WIRE_FRAME_FEMALE: r"(?i-u)^female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female$",
-    GIGA_BOWSER: r"(?i-u)^giga[ _]?bowser$",
-    CRAZY_HAND: r"(?i-u)^crazy[ _]?hand$",
-    SANDBAG: r"(?i-u)^sandbag$",
-    POPO: r"(?i-u)^popo$",
-});

--- a/peppi/src/info/character.rs
+++ b/peppi/src/info/character.rs
@@ -1,0 +1,281 @@
+use crate::model::enums::character::External;
+
+#[derive(Clone)]
+pub struct Info {
+	pub external: External,
+	pub short: &'static str,
+	pub long: &'static str,
+	pub traction: f32,
+}
+
+macro_rules! char_info {
+	($info: ident {
+		$($name: ident {
+			regex: $regex: expr,
+			$( $field: ident : $value: expr ),* $(,)?
+		});* $(;)?
+	}) => {
+		mod regexes {
+			use lazy_static::lazy_static;
+			use regex::Regex;
+			lazy_static! {
+				$( pub static ref $name: Regex = Regex::new($regex).unwrap(); )*
+			}
+		}
+
+		impl $info {
+			pub fn try_from(external: External) -> Option<$info> {
+				match external {
+					$( External::$name => Some($name), )*
+					_ => None
+				}
+			}
+
+			pub fn try_match(s: &str) -> Option<$info> {
+				match s {
+					$( s if regexes::$name.is_match(s) => Some($name), )*
+					_ => None,
+				}
+			}
+		}
+
+		$(pub const $name: $info = $info {
+			external: External::$name,
+			$( $field: $value ),*
+		};)*
+	}
+}
+
+
+char_info!(Info {
+	CAPTAIN_FALCON {
+		regex: r"(?i-u)(capt(ain|\.)?[ _]?)?falcon",
+		short: "Falcon",
+		long: "Captain Falcon",
+		traction: 0.08,
+	};
+
+	DONKEY_KONG {
+		regex: r"(?i-u)dk|(donkey[ _]?kong",
+		short: "DK",
+		long: "Donkey Kong",
+		traction: 0.08,
+	};
+
+	FOX {
+		regex: r"(?i-u)fox",
+		short: "Fox",
+		long: "Fox",
+		traction: 0.08,
+	};
+
+	GAME_AND_WATCH {
+		regex: r"(?i-u)(g|game)[ _]?(and|&|n)[ _]?(w|watch)",
+		short: "G&W",
+		long: "Game and Watch",
+		traction: 0.06,
+	};
+
+	KIRBY {
+		regex: r"(?i-u)kirby",
+		short: "Kirby",
+		long: "Kirby",
+		traction: 0.08,
+	};
+
+	BOWSER {
+		regex: r"(?i-u)bowser",
+		short: "Bowser",
+		long: "Bowser",
+		traction: 0.06,
+	};
+
+	LINK {
+		regex: r"(?i-u)link",
+		short: "Link",
+		long: "Link",
+		traction: 0.1,
+	};
+
+	LUIGI {
+		regex: r"(?i-u)luigi",
+		short: "Luigi",
+		long: "Luigi",
+		traction: 0.025,
+	};
+
+	MARIO {
+		regex: r"(?i-u)mario",
+		short: "Mario",
+		long: "Mario",
+		traction: 0.06,
+	};
+
+	MARTH {
+		regex: r"(?i-u)marth",
+		short: "Marth",
+		long: "Marth",
+		traction: 0.06,
+	};
+
+	MEWTWO {
+		regex: r"(?i-u)mewtwo|mew2|m2",
+		short: "Mewtwo",
+		long: "Mewtwo",
+		traction: 0.04,
+	};
+
+	NESS {
+		regex: r"(?i-u)ness",
+		short: "Ness",
+		long: "Ness",
+		traction: 0.06,
+	};
+
+	PEACH {
+		regex: r"(?i-u)peach",
+		short: "Peach",
+		long: "Peach",
+		traction: 0.1,
+	};
+
+	PIKACHU {
+		regex: r"(?i-u)pika(chu)?",
+		short: "Pika",
+		long: "Pikachu",
+		traction: 0.09,
+	};
+
+	ICE_CLIMBERS {
+		regex: r"(?i-u)ic(|s|ies|e[ _]?climbers)",
+		short: "ICs",
+		long: "Ice Climbers",
+		traction: 0.035,
+	};
+
+	JIGGLYPUFF {
+		regex: r"(?i-u)(jiggly)?puff|jiggs",
+		short: "Puff",
+		long: "Jigglypuff",
+		traction: 0.09,
+	};
+
+	SAMUS {
+		regex: r"(?i-u)samus",
+		short: "Samus",
+		long: "Samus",
+		traction: 0.06,
+	};
+
+	YOSHI {
+		regex: r"(?i-u)yoshi",
+		short: "Yoshi",
+		long: "Yoshi",
+		traction: 0.06,
+	};
+
+	ZELDA {
+		regex: r"(?i-u)zelda",
+		short: "Zelda",
+		long: "Zelda",
+		traction: 0.1,
+	};
+
+	SHEIK {
+		regex: r"(?i-u)sheik",
+		short: "Sheik",
+		long: "Sheik",
+		traction: 0.08,
+	};
+
+	FALCO {
+		regex: r"(?i-u)falco",
+		short: "Falco",
+		long: "Falco",
+		traction: 0.08,
+	};
+
+	YOUNG_LINK {
+		regex: r"(?i-u)(y\.?|young)[ _]?(l|link",
+		short: "YL",
+		long: "Young Link",
+		traction: 0.08,
+	};
+
+	DR_MARIO {
+		regex: r"(?i-u)doc|dr\.?[ _]?mario",
+		short: "Doc",
+		long: "Dr. Mario",
+		traction: 0.06,
+	};
+
+	ROY {
+		regex: r"(?i-u)roy",
+		short: "Roy",
+		long: "Roy",
+		traction: 0.06,
+	};
+
+	PICHU {
+		regex: r"(?i-u)pichu",
+		short: "Pichu",
+		long: "Pichu",
+		traction: 0.1,
+	};
+
+	GANONDORF {
+		regex: r"(?i-u)ganon(dorf)?",
+		short: "Ganon",
+		long: "Ganondorf",
+		traction: 0.07,
+	};
+
+	MASTER_HAND {
+		regex: r"(?i-u)master[ _]?hand",
+		short: "Master Hand",
+		long: "Master Hand",
+		traction: 0.0,
+	};
+
+	WIRE_FRAME_MALE {
+		regex: r"(?i-u)male[ _]?wire[ _]?frame|wire[ _]?frame[ _]?male",
+		short: "Male Wireframe",
+		long: "Male Wireframe",
+		traction: 0.0,
+	};
+
+	WIRE_FRAME_FEMALE {
+		regex: r"(?i-u)female[ _]?wire[ _]?frame|wire[ _]?frame[ _]?female",
+		short: "Female Wireframe",
+		long: "Female Wireframe",
+		traction: 0.0,
+	};
+
+	GIGA_BOWSER {
+		regex: r"(?i-u)giga[ _]?bowser",
+		short: "Giga Bowser",
+		long: "Giga Bowser",
+		traction: 0.0,
+	};
+
+	CRAZY_HAND {
+		regex: r"(?i-u)crazy[ _]?hand",
+		short: "Crazy Hand",
+		long: "Crazy Hand",
+		traction: 0.0,
+	};
+
+	SANDBAG {
+		regex: r"(?i-u)sandbag",
+		short: "Sandbag",
+		long: "Sandbag",
+		traction: 0.0,
+	};
+
+	POPO {
+		regex: r"(?i-u)popo",
+		short: "Popo",
+		long: "Popo",
+		traction: 0.035,
+	};
+});

--- a/peppi/src/info/info.rs
+++ b/peppi/src/info/info.rs
@@ -1,0 +1,43 @@
+macro_rules! info {
+	($type: path => $info: ident {
+		$($name: ident {
+			$( $field: ident : $value: expr ),+ $(,)?
+		});+ $(;)?
+	}) => {
+		impl $info {
+			pub fn try_from(value: $type) -> Option<$info> {
+				match value {
+					$( <$type>::$name => Some($name), )*
+					_ => None
+				}
+			}
+		}
+
+		$(pub const $name: $info = $info {
+			$( $field: $value ),*
+		};)*
+	}
+}
+
+macro_rules! info_regex {
+	($info: ident {
+        $($name: ident : $regex: expr),+ $(,)?
+    }) => {
+		mod regexes {
+			use lazy_static::lazy_static;
+			use regex::Regex;
+			lazy_static! {
+				$( pub static ref $name: Regex = Regex::new($regex).unwrap(); )*
+			}
+		}
+
+		impl $info {
+			pub fn try_match(s: &str) -> Option<$info> {
+				match s {
+					$( s if regexes::$name.is_match(s) => Some($name), )*
+					_ => None,
+				}
+			}
+		}
+	}
+}

--- a/peppi/src/info/info.rs
+++ b/peppi/src/info/info.rs
@@ -18,26 +18,3 @@ macro_rules! info {
 		};)*
 	}
 }
-
-macro_rules! info_regex {
-	($info: ident {
-        $($name: ident : $regex: expr),+ $(,)?
-    }) => {
-		mod regexes {
-			use lazy_static::lazy_static;
-			use regex::Regex;
-			lazy_static! {
-				$( pub static ref $name: Regex = Regex::new($regex).unwrap(); )*
-			}
-		}
-
-		impl $info {
-			pub fn try_match(s: &str) -> Option<$info> {
-				match s {
-					$( s if regexes::$name.is_match(s) => Some($name), )*
-					_ => None,
-				}
-			}
-		}
-	}
-}

--- a/peppi/src/info/stage.rs
+++ b/peppi/src/info/stage.rs
@@ -185,37 +185,3 @@ info!(Stage => Info {
         long: "Final Destination",
     };
 });
-
-info_regex!(Info {
-    // Common stages at top to save regex time in common case
-	FOUNTAIN_OF_DREAMS: r"(?i-u)^fod|fountain([ _]?of[ _]?dreams)?$",
-	POKEMON_STADIUM: r"(?i-u)^ps|pokemon([ _]?stadium([ _]?[1I])?)?$",
-	YOSHIS_STORY: r"(?i-u)^ys|yoshi'?s[ _]?story$",
-	DREAM_LAND_N64: r"(?i-u)^(dl|dream[ _]?land)[ _]?(N?64)?$",
-	BATTLEFIELD: r"(?i-u)^bf|battle[ _]?field$",
-	FINAL_DESTINATION: r"(?i-u)^fd|final[ _]?destination$",
-
-	PRINCESS_PEACHS_CASTLE: r"(?i-u)^ppc|princess[ _]?peach'?s[ _]?castle$",
-	KONGO_JUNGLE: r"(?i-u)^kj|kongo[ _]?jungle$",
-	BRINSTAR: r"(?i-u)^brinstar$",
-	CORNERIA: r"(?i-u)^corneria$",
-	ONETT: r"(?i-u)^onett$",
-	MUTE_CITY: r"(?i-u)^mc|mute[ _]?city$",
-	RAINBOW_CRUISE: r"(?i-u)^rc|rainbow[ _]?cruise$",
-	JUNGLE_JAPES: r"(?i-u)^jj|jungle[ _]?japes$",
-	GREAT_BAY: r"(?i-u)^gb|great[ _]?bay$",
-	HYRULE_TEMPLE: r"(?i-u)^ht|hyrule[ _]?temple$",
-	BRINSTAR_DEPTHS: r"(?i-u)^bd|brinstar[ _]?depths$",
-	YOSHIS_ISLAND: r"(?i-u)^yi|yoshi'?s[ _]?island$",
-	GREEN_GREENS: r"(?i-u)^gg|green[ _]?greens$",
-	FOURSIDE: r"(?i-u)^fourside$",
-	MUSHROOM_KINGDOM_I: r"(?i-u)^(mk|mushroom[ _]?kingdom)[1i]?$",
-	MUSHROOM_KINGDOM_II: r"(?i-u)^(mk|mushroom[ _]?kingdom)(2|ii)$",
-	VENOM: r"(?i-u)^venom$",
-	POKE_FLOATS: r"(?i-u)^pf|poke[ _]?floats$",
-	BIG_BLUE: r"(?i-u)^bb|big[ _]?blue$",
-	ICICLE_MOUNTAIN: r"(?i-u)^im|icicle[ _]?mountain$",
-	FLAT_ZONE: r"(?i-u)^fz|flat[ _]?zone$",
-	YOSHIS_ISLAND_N64: r"(?i-u)^(yi|yoshi'?s[ _]?island)[ _]?(N?64)$",
-	KONGO_JUNGLE_N64: r"(?i-u)^(kj|kongo[ _]?jungle)[ _]?(N?64)$",
-});

--- a/peppi/src/info/stage.rs
+++ b/peppi/src/info/stage.rs
@@ -1,0 +1,221 @@
+use crate::model::enums::stage::Stage;
+
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub struct Info {
+    pub stage: Stage,
+    pub short: &'static str,
+    pub long: &'static str,
+}
+
+info!(Stage => Info {
+	FOUNTAIN_OF_DREAMS {
+        stage: Stage::FOUNTAIN_OF_DREAMS,
+        short: "FoD",
+        long: "Fountain of Dreams",
+    };
+
+	POKEMON_STADIUM {
+        stage: Stage::POKEMON_STADIUM,
+        short: "PS",
+        long: "Pokemon Stadium",
+    };
+
+	PRINCESS_PEACHS_CASTLE {
+        stage: Stage::PRINCESS_PEACHS_CASTLE,
+        short: "PPC",
+        long: "Princess Peach's Castle",
+    };
+
+	KONGO_JUNGLE {
+        stage: Stage::KONGO_JUNGLE,
+        short: "KJ",
+        long: "Kongo Jungle",
+    };
+
+	BRINSTAR {
+        stage: Stage::BRINSTAR,
+        short: "Brinstar",
+        long: "Brinstar",
+    };
+
+	CORNERIA {
+        stage: Stage::CORNERIA,
+        short: "Corneria",
+        long: "Corneria",
+    };
+
+	YOSHIS_STORY {
+        stage: Stage::YOSHIS_STORY,
+        short: "YS",
+        long: "Yoshi's Story",
+    };
+
+	ONETT {
+        stage: Stage::ONETT,
+        short: "Onett",
+        long: "Onett",
+    };
+
+	MUTE_CITY {
+        stage: Stage::MUTE_CITY,
+        short: "MC",
+        long: "Mute City",
+    };
+
+	RAINBOW_CRUISE {
+        stage: Stage::RAINBOW_CRUISE,
+        short: "RC",
+        long: "Rainbow Cruise",
+    };
+
+	JUNGLE_JAPES {
+        stage: Stage::JUNGLE_JAPES,
+        short: "JJ",
+        long: "Jungle Japes",
+    };
+
+	GREAT_BAY {
+        stage: Stage::GREAT_BAY,
+        short: "GB",
+        long: "Great Bay",
+    };
+
+	HYRULE_TEMPLE {
+        stage: Stage::HYRULE_TEMPLE,
+        short: "HT",
+        long: "Hyrule Temple",
+    };
+
+	BRINSTAR_DEPTHS {
+        stage: Stage::BRINSTAR_DEPTHS,
+        short: "BD",
+        long: "Brinstar Depths",
+    };
+
+	YOSHIS_ISLAND {
+        stage: Stage::YOSHIS_ISLAND,
+        short: "YI",
+        long: "Yoshi's Island",
+    };
+
+	GREEN_GREENS {
+        stage: Stage::GREEN_GREENS,
+        short: "GG",
+        long: "Green Greens",
+    };
+
+	FOURSIDE {
+        stage: Stage::FOURSIDE,
+        short: "Fourside",
+        long: "Fourside",
+    };
+
+	MUSHROOM_KINGDOM_I {
+        stage: Stage::MUSHROOM_KINGDOM_I,
+        short: "MKI",
+        long: "Mushroom Kingdom I",
+    };
+
+	MUSHROOM_KINGDOM_II {
+        stage: Stage::MUSHROOM_KINGDOM_II,
+        short: "MKII",
+        long: "Mushroom Kingdom II",
+    };
+
+	VENOM {
+        stage: Stage::VENOM,
+        short: "Venom",
+        long: "Venom",
+    };
+
+	POKE_FLOATS {
+        stage: Stage::POKE_FLOATS,
+        short: "PF",
+        long: "Poke Floats",
+    };
+
+	BIG_BLUE {
+        stage: Stage::BIG_BLUE,
+        short: "BB",
+        long: "Big Blue",
+    };
+
+	ICICLE_MOUNTAIN {
+        stage: Stage::ICICLE_MOUNTAIN,
+        short: "IM",
+        long: "Icicle Mountain",
+    };
+
+    // No ICETOP (unplayable in melee without hacks)
+
+	FLAT_ZONE {
+        stage: Stage::FLAT_ZONE,
+        short: "FZ",
+        long: "Flat Zone",
+    };
+
+	DREAM_LAND_N64 {
+        stage: Stage::DREAM_LAND_N64,
+        short: "DL64",
+        long: "Dream Land N64",
+    };
+
+	YOSHIS_ISLAND_N64 {
+        stage: Stage::YOSHIS_ISLAND_N64,
+        short: "YI64",
+        long: "Yoshi's Island N64",
+    };
+
+	KONGO_JUNGLE_N64 {
+        stage: Stage::KONGO_JUNGLE_N64,
+        short: "KJ64",
+        long: "Kongo Jungle N64",
+    };
+
+	BATTLEFIELD {
+        stage: Stage::BATTLEFIELD,
+        short: "BF",
+        long: "Battlefield",
+    };
+
+	FINAL_DESTINATION {
+        stage: Stage::FINAL_DESTINATION,
+        short: "FD",
+        long: "Final Destination",
+    };
+});
+
+info_regex!(Info {
+    // Common stages at top to save regex time in common case
+	FOUNTAIN_OF_DREAMS: r"(?i-u)^fod|fountain([ _]?of[ _]?dreams)?$",
+	POKEMON_STADIUM: r"(?i-u)^ps|pokemon([ _]?stadium([ _]?[1I])?)?$",
+	YOSHIS_STORY: r"(?i-u)^ys|yoshi'?s[ _]?story$",
+	DREAM_LAND_N64: r"(?i-u)^(dl|dream[ _]?land)[ _]?(N?64)?$",
+	BATTLEFIELD: r"(?i-u)^bf|battle[ _]?field$",
+	FINAL_DESTINATION: r"(?i-u)^fd|final[ _]?destination$",
+
+	PRINCESS_PEACHS_CASTLE: r"(?i-u)^ppc|princess[ _]?peach'?s[ _]?castle$",
+	KONGO_JUNGLE: r"(?i-u)^kj|kongo[ _]?jungle$",
+	BRINSTAR: r"(?i-u)^brinstar$",
+	CORNERIA: r"(?i-u)^corneria$",
+	ONETT: r"(?i-u)^onett$",
+	MUTE_CITY: r"(?i-u)^mc|mute[ _]?city$",
+	RAINBOW_CRUISE: r"(?i-u)^rc|rainbow[ _]?cruise$",
+	JUNGLE_JAPES: r"(?i-u)^jj|jungle[ _]?japes$",
+	GREAT_BAY: r"(?i-u)^gb|great[ _]?bay$",
+	HYRULE_TEMPLE: r"(?i-u)^ht|hyrule[ _]?temple$",
+	BRINSTAR_DEPTHS: r"(?i-u)^bd|brinstar[ _]?depths$",
+	YOSHIS_ISLAND: r"(?i-u)^yi|yoshi'?s[ _]?island$",
+	GREEN_GREENS: r"(?i-u)^gg|green[ _]?greens$",
+	FOURSIDE: r"(?i-u)^fourside$",
+	MUSHROOM_KINGDOM_I: r"(?i-u)^(mk|mushroom[ _]?kingdom)[1i]?$",
+	MUSHROOM_KINGDOM_II: r"(?i-u)^(mk|mushroom[ _]?kingdom)(2|ii)$",
+	VENOM: r"(?i-u)^venom$",
+	POKE_FLOATS: r"(?i-u)^pf|poke[ _]?floats$",
+	BIG_BLUE: r"(?i-u)^bb|big[ _]?blue$",
+	ICICLE_MOUNTAIN: r"(?i-u)^im|icicle[ _]?mountain$",
+	FLAT_ZONE: r"(?i-u)^fz|flat[ _]?zone$",
+	YOSHIS_ISLAND_N64: r"(?i-u)^(yi|yoshi'?s[ _]?island)[ _]?(N?64)$",
+	KONGO_JUNGLE_N64: r"(?i-u)^(kj|kongo[ _]?jungle)[ _]?(N?64)$",
+});

--- a/peppi/src/info/stage.rs
+++ b/peppi/src/info/stage.rs
@@ -3,146 +3,122 @@ use crate::model::enums::stage::Stage;
 #[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct Info {
-    pub stage: Stage,
     pub short_name: &'static str,
     pub long_name: &'static str,
 }
 
 info!(Stage => Info {
 	FOUNTAIN_OF_DREAMS {
-        stage: Stage::FOUNTAIN_OF_DREAMS,
         short_name: "FoD",
         long_name: "Fountain of Dreams",
     };
 
 	POKEMON_STADIUM {
-        stage: Stage::POKEMON_STADIUM,
         short_name: "PS",
         long_name: "Pokemon Stadium",
     };
 
 	PRINCESS_PEACHS_CASTLE {
-        stage: Stage::PRINCESS_PEACHS_CASTLE,
         short_name: "PPC",
         long_name: "Princess Peach's Castle",
     };
 
 	KONGO_JUNGLE {
-        stage: Stage::KONGO_JUNGLE,
         short_name: "KJ",
         long_name: "Kongo Jungle",
     };
 
 	BRINSTAR {
-        stage: Stage::BRINSTAR,
         short_name: "Brinstar",
         long_name: "Brinstar",
     };
 
 	CORNERIA {
-        stage: Stage::CORNERIA,
         short_name: "Corneria",
         long_name: "Corneria",
     };
 
 	YOSHIS_STORY {
-        stage: Stage::YOSHIS_STORY,
         short_name: "YS",
         long_name: "Yoshi's Story",
     };
 
 	ONETT {
-        stage: Stage::ONETT,
         short_name: "Onett",
         long_name: "Onett",
     };
 
 	MUTE_CITY {
-        stage: Stage::MUTE_CITY,
         short_name: "MC",
         long_name: "Mute City",
     };
 
 	RAINBOW_CRUISE {
-        stage: Stage::RAINBOW_CRUISE,
         short_name: "RC",
         long_name: "Rainbow Cruise",
     };
 
 	JUNGLE_JAPES {
-        stage: Stage::JUNGLE_JAPES,
         short_name: "JJ",
         long_name: "Jungle Japes",
     };
 
 	GREAT_BAY {
-        stage: Stage::GREAT_BAY,
         short_name: "GB",
         long_name: "Great Bay",
     };
 
 	HYRULE_TEMPLE {
-        stage: Stage::HYRULE_TEMPLE,
         short_name: "HT",
         long_name: "Hyrule Temple",
     };
 
 	BRINSTAR_DEPTHS {
-        stage: Stage::BRINSTAR_DEPTHS,
         short_name: "BD",
         long_name: "Brinstar Depths",
     };
 
 	YOSHIS_ISLAND {
-        stage: Stage::YOSHIS_ISLAND,
         short_name: "YI",
         long_name: "Yoshi's Island",
     };
 
 	GREEN_GREENS {
-        stage: Stage::GREEN_GREENS,
         short_name: "GG",
         long_name: "Green Greens",
     };
 
 	FOURSIDE {
-        stage: Stage::FOURSIDE,
         short_name: "Fourside",
         long_name: "Fourside",
     };
 
 	MUSHROOM_KINGDOM_I {
-        stage: Stage::MUSHROOM_KINGDOM_I,
         short_name: "MKI",
         long_name: "Mushroom Kingdom I",
     };
 
 	MUSHROOM_KINGDOM_II {
-        stage: Stage::MUSHROOM_KINGDOM_II,
         short_name: "MKII",
         long_name: "Mushroom Kingdom II",
     };
 
 	VENOM {
-        stage: Stage::VENOM,
         short_name: "Venom",
         long_name: "Venom",
     };
 
 	POKE_FLOATS {
-        stage: Stage::POKE_FLOATS,
         short_name: "PF",
         long_name: "Poke Floats",
     };
 
 	BIG_BLUE {
-        stage: Stage::BIG_BLUE,
         short_name: "BB",
         long_name: "Big Blue",
     };
 
 	ICICLE_MOUNTAIN {
-        stage: Stage::ICICLE_MOUNTAIN,
         short_name: "IM",
         long_name: "Icicle Mountain",
     };
@@ -150,37 +126,31 @@ info!(Stage => Info {
     // No ICETOP (unplayable in melee without hacks)
 
 	FLAT_ZONE {
-        stage: Stage::FLAT_ZONE,
         short_name: "FZ",
         long_name: "Flat Zone",
     };
 
 	DREAM_LAND_N64 {
-        stage: Stage::DREAM_LAND_N64,
         short_name: "DL64",
         long_name: "Dream Land N64",
     };
 
 	YOSHIS_ISLAND_N64 {
-        stage: Stage::YOSHIS_ISLAND_N64,
         short_name: "YI64",
         long_name: "Yoshi's Island N64",
     };
 
 	KONGO_JUNGLE_N64 {
-        stage: Stage::KONGO_JUNGLE_N64,
         short_name: "KJ64",
         long_name: "Kongo Jungle N64",
     };
 
 	BATTLEFIELD {
-        stage: Stage::BATTLEFIELD,
         short_name: "BF",
         long_name: "Battlefield",
     };
 
 	FINAL_DESTINATION {
-        stage: Stage::FINAL_DESTINATION,
         short_name: "FD",
         long_name: "Final Destination",
     };

--- a/peppi/src/info/stage.rs
+++ b/peppi/src/info/stage.rs
@@ -4,184 +4,184 @@ use crate::model::enums::stage::Stage;
 #[derive(Clone, Debug)]
 pub struct Info {
     pub stage: Stage,
-    pub short: &'static str,
-    pub long: &'static str,
+    pub short_name: &'static str,
+    pub long_name: &'static str,
 }
 
 info!(Stage => Info {
 	FOUNTAIN_OF_DREAMS {
         stage: Stage::FOUNTAIN_OF_DREAMS,
-        short: "FoD",
-        long: "Fountain of Dreams",
+        short_name: "FoD",
+        long_name: "Fountain of Dreams",
     };
 
 	POKEMON_STADIUM {
         stage: Stage::POKEMON_STADIUM,
-        short: "PS",
-        long: "Pokemon Stadium",
+        short_name: "PS",
+        long_name: "Pokemon Stadium",
     };
 
 	PRINCESS_PEACHS_CASTLE {
         stage: Stage::PRINCESS_PEACHS_CASTLE,
-        short: "PPC",
-        long: "Princess Peach's Castle",
+        short_name: "PPC",
+        long_name: "Princess Peach's Castle",
     };
 
 	KONGO_JUNGLE {
         stage: Stage::KONGO_JUNGLE,
-        short: "KJ",
-        long: "Kongo Jungle",
+        short_name: "KJ",
+        long_name: "Kongo Jungle",
     };
 
 	BRINSTAR {
         stage: Stage::BRINSTAR,
-        short: "Brinstar",
-        long: "Brinstar",
+        short_name: "Brinstar",
+        long_name: "Brinstar",
     };
 
 	CORNERIA {
         stage: Stage::CORNERIA,
-        short: "Corneria",
-        long: "Corneria",
+        short_name: "Corneria",
+        long_name: "Corneria",
     };
 
 	YOSHIS_STORY {
         stage: Stage::YOSHIS_STORY,
-        short: "YS",
-        long: "Yoshi's Story",
+        short_name: "YS",
+        long_name: "Yoshi's Story",
     };
 
 	ONETT {
         stage: Stage::ONETT,
-        short: "Onett",
-        long: "Onett",
+        short_name: "Onett",
+        long_name: "Onett",
     };
 
 	MUTE_CITY {
         stage: Stage::MUTE_CITY,
-        short: "MC",
-        long: "Mute City",
+        short_name: "MC",
+        long_name: "Mute City",
     };
 
 	RAINBOW_CRUISE {
         stage: Stage::RAINBOW_CRUISE,
-        short: "RC",
-        long: "Rainbow Cruise",
+        short_name: "RC",
+        long_name: "Rainbow Cruise",
     };
 
 	JUNGLE_JAPES {
         stage: Stage::JUNGLE_JAPES,
-        short: "JJ",
-        long: "Jungle Japes",
+        short_name: "JJ",
+        long_name: "Jungle Japes",
     };
 
 	GREAT_BAY {
         stage: Stage::GREAT_BAY,
-        short: "GB",
-        long: "Great Bay",
+        short_name: "GB",
+        long_name: "Great Bay",
     };
 
 	HYRULE_TEMPLE {
         stage: Stage::HYRULE_TEMPLE,
-        short: "HT",
-        long: "Hyrule Temple",
+        short_name: "HT",
+        long_name: "Hyrule Temple",
     };
 
 	BRINSTAR_DEPTHS {
         stage: Stage::BRINSTAR_DEPTHS,
-        short: "BD",
-        long: "Brinstar Depths",
+        short_name: "BD",
+        long_name: "Brinstar Depths",
     };
 
 	YOSHIS_ISLAND {
         stage: Stage::YOSHIS_ISLAND,
-        short: "YI",
-        long: "Yoshi's Island",
+        short_name: "YI",
+        long_name: "Yoshi's Island",
     };
 
 	GREEN_GREENS {
         stage: Stage::GREEN_GREENS,
-        short: "GG",
-        long: "Green Greens",
+        short_name: "GG",
+        long_name: "Green Greens",
     };
 
 	FOURSIDE {
         stage: Stage::FOURSIDE,
-        short: "Fourside",
-        long: "Fourside",
+        short_name: "Fourside",
+        long_name: "Fourside",
     };
 
 	MUSHROOM_KINGDOM_I {
         stage: Stage::MUSHROOM_KINGDOM_I,
-        short: "MKI",
-        long: "Mushroom Kingdom I",
+        short_name: "MKI",
+        long_name: "Mushroom Kingdom I",
     };
 
 	MUSHROOM_KINGDOM_II {
         stage: Stage::MUSHROOM_KINGDOM_II,
-        short: "MKII",
-        long: "Mushroom Kingdom II",
+        short_name: "MKII",
+        long_name: "Mushroom Kingdom II",
     };
 
 	VENOM {
         stage: Stage::VENOM,
-        short: "Venom",
-        long: "Venom",
+        short_name: "Venom",
+        long_name: "Venom",
     };
 
 	POKE_FLOATS {
         stage: Stage::POKE_FLOATS,
-        short: "PF",
-        long: "Poke Floats",
+        short_name: "PF",
+        long_name: "Poke Floats",
     };
 
 	BIG_BLUE {
         stage: Stage::BIG_BLUE,
-        short: "BB",
-        long: "Big Blue",
+        short_name: "BB",
+        long_name: "Big Blue",
     };
 
 	ICICLE_MOUNTAIN {
         stage: Stage::ICICLE_MOUNTAIN,
-        short: "IM",
-        long: "Icicle Mountain",
+        short_name: "IM",
+        long_name: "Icicle Mountain",
     };
 
     // No ICETOP (unplayable in melee without hacks)
 
 	FLAT_ZONE {
         stage: Stage::FLAT_ZONE,
-        short: "FZ",
-        long: "Flat Zone",
+        short_name: "FZ",
+        long_name: "Flat Zone",
     };
 
 	DREAM_LAND_N64 {
         stage: Stage::DREAM_LAND_N64,
-        short: "DL64",
-        long: "Dream Land N64",
+        short_name: "DL64",
+        long_name: "Dream Land N64",
     };
 
 	YOSHIS_ISLAND_N64 {
         stage: Stage::YOSHIS_ISLAND_N64,
-        short: "YI64",
-        long: "Yoshi's Island N64",
+        short_name: "YI64",
+        long_name: "Yoshi's Island N64",
     };
 
 	KONGO_JUNGLE_N64 {
         stage: Stage::KONGO_JUNGLE_N64,
-        short: "KJ64",
-        long: "Kongo Jungle N64",
+        short_name: "KJ64",
+        long_name: "Kongo Jungle N64",
     };
 
 	BATTLEFIELD {
         stage: Stage::BATTLEFIELD,
-        short: "BF",
-        long: "Battlefield",
+        short_name: "BF",
+        long_name: "Battlefield",
     };
 
 	FINAL_DESTINATION {
         stage: Stage::FINAL_DESTINATION,
-        short: "FD",
-        long: "Final Destination",
+        short_name: "FD",
+        long_name: "Final Destination",
     };
 });

--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -53,6 +53,7 @@ pub mod model {
 }
 
 pub mod info {
+	#[macro_use] #[doc(hidden)] pub(crate) mod info;
 	pub mod character;
 }
 

--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -52,6 +52,10 @@ pub mod model {
 	}
 }
 
+pub mod info {
+	pub mod character;
+}
+
 pub mod serde {
 	pub mod arrow;
 	pub mod collect;

--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -55,6 +55,7 @@ pub mod model {
 pub mod info {
 	#[macro_use] #[doc(hidden)] pub(crate) mod info;
 	pub mod character;
+	pub mod stage;
 }
 
 pub mod serde {


### PR DESCRIPTION
I took your suggestion and put relevant info (display names, useful constants, and matching) inside a single module/struct. I finished characters and stages, I might add modules for items, attacks, and actions.

Using regex requires the `regex` and `lazy_static` crates. I disabled unicode features in regex to make it a little lighter and lazy_static is already pretty light. Let me know if you have concerns with bloat or anything. It would be possible to hide the info modules behind a feature.

~For now the only data constant is traction, but~ I assume we would want things like gravity, weight, etc. Finding reliable and universal data for some of these is tricky. I'd like to avoid making the type of these constants optional. Maybe best is to remove the unplayable characters.

~Also, display names make more sense to be associated with `External` characters whereas constants like traction probably make more sense to belong with `Internal` characters. Do you think it makes sense to have a parallel `Internal` `Info` struct? Really, Ice Climbers are the annoying edge case here.~ Edit: I decided to make internal and external info structs separate.