### PR TITLE
Parse fourth version byte

### DIFF
--- a/peppi/src/model/game.rs
+++ b/peppi/src/model/game.rs
@@ -21,7 +21,7 @@ pub const FIRST_FRAME_INDEX: i32 = -123;
 /// We can parse files with higher versions than this, but we won't expose all information.
 /// When converting a replay with a higher version number to another format like Arrow,
 /// the conversion will be lossy.
-pub const MAX_SUPPORTED_VERSION: slippi::Version = slippi::Version(3, 9, 0);
+pub const MAX_SUPPORTED_VERSION: slippi::Version = slippi::Version(3, 12, 0, 0);
 
 pseudo_enum!(PlayerType: u8 {
 	0 => HUMAN,

--- a/peppi/src/model/slippi.rs
+++ b/peppi/src/model/slippi.rs
@@ -3,10 +3,10 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd, Deserialize, Serialize)]
-pub struct Version(pub u8, pub u8, pub u8);
+pub struct Version(pub u8, pub u8, pub u8, pub u8);
 
 pub const fn version(major: u8, minor: u8) -> Version {
-	Version(major, minor, 0)
+	Version(major, minor, 0, 0)
 }
 
 pub struct ParseVersionError(pub String);
@@ -23,9 +23,10 @@ impl TryFrom<&str> for Version {
 		let v: Vec<u8> = s.split('.').map(|s| s.parse::<u8>()).collect::<Result<Vec<u8>, std::num::ParseIntError>>()?;
 		match v.len() {
 			0 => unreachable!(),
-			1 => Ok(Version(v[0], 0, 0)),
-			2 => Ok(Version(v[0], v[1], 0)),
-			3 => Ok(Version(v[0], v[1], v[3])),
+			1 => Ok(Version(v[0], 0, 0, 0)),
+			2 => Ok(Version(v[0], v[1], 0, 0)),
+			3 => Ok(Version(v[0], v[1], v[2], 0)),
+			4 => Ok(Version(v[0], v[1], v[2], v[3])),
 			_ => Err(ParseVersionError("too many components".to_string())),
 		}
 	}
@@ -33,7 +34,7 @@ impl TryFrom<&str> for Version {
 
 impl fmt::Display for Version {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{}.{}.{}", self.0, self.1, self.2)
+		write!(f, "{}.{}.{}.{}", self.0, self.1, self.2, self.3)
 	}
 }
 

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -310,9 +310,8 @@ fn player_bytes_v1_0(r: &mut &[u8]) -> Result<[u8; 8]> {
 fn game_start(mut r: &mut &[u8]) -> Result<game::Start> {
 	let raw_bytes = r.to_vec();
 	let slippi = slippi::Slippi {
-		version: slippi::Version(r.read_u8()?, r.read_u8()?, r.read_u8()?),
+		version: slippi::Version(r.read_u8()?, r.read_u8()?, r.read_u8()?, r.read_u8()?),
 	};
-	r.read_u8()?; // unused (build number)
 
 	let mut unmapped = [0; 73];
 	let bitfield = {

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -54,7 +54,7 @@ fn slippi_old_version() -> Result<(), String> {
 	let game = game("v0.1")?;
 	let players = game.start.players;
 
-	assert_eq!(game.start.slippi.version, Version(0, 1, 0));
+	assert_eq!(game.start.slippi.version, Version(0, 1, 0, 0));
 	assert_eq!(game.metadata.duration, None);
 
 	assert_eq!(players.len(), 2);
@@ -96,7 +96,7 @@ fn basic_game() -> Result<(), String> {
 	});
 
 	assert_eq!(game.start, Start {
-		slippi: Slippi { version: Version(1, 0, 0) },
+		slippi: Slippi { version: Version(1, 0, 0, 0) },
 		bitfield: [50, 1, 134, 76],
 		is_raining_bombs: false,
 		is_teams: false,
@@ -366,7 +366,7 @@ fn console_name() -> Result<(), String> {
 #[test]
 fn v2() -> Result<(), String> {
 	let game = game("v2.0")?;
-	assert_eq!(game.start.slippi.version, Version(2, 0, 1));
+	assert_eq!(game.start.slippi.version, Version(2, 0, 1, 0));
 	Ok(())
 }
 
@@ -375,7 +375,7 @@ fn v3_12() -> Result<(), String> {
 	let game = game("v3.12")?;
 
 	assert_eq!(game.start, Start {
-		slippi: Slippi { version: Version(3, 12, 0) },
+		slippi: Slippi { version: Version(3, 12, 0, 0) },
 		bitfield: [50, 1, 142, 76],
 		is_raining_bombs: false,
 		is_teams: false,


### PR DESCRIPTION
Adds fourth version byte to the `Version` struct and parses it (instead of dropping it like before). I know it is currently unused, but I'm interested in adding it because [slippc](https://github.com/pcrain/slippc/tree/master/src) stores a value there for compressed replay files (which I'm looking into adding support for). Maybe a future replay spec will use it too?

Updates `MAX_SUPPORTED_VERSION` to v3.12

Fixes incorrect index used in `TryFrom<&str> for Version`