### PR TITLE
Bump arrow to v20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 **/*.rs.bk
+.vscode

--- a/peppi-arrow/Cargo.toml
+++ b/peppi-arrow/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/hohav/peppi"
 version = "0.2.3"
 
 [dependencies]
-arrow = "7.0"
+arrow = "20.0.0"

--- a/peppi-arrow/src/lib.rs
+++ b/peppi-arrow/src/lib.rs
@@ -67,11 +67,11 @@ macro_rules! primitives {
 			}
 
 			fn write<C: Context>(&self, builder: &mut dyn ArrayBuilder, _context: C) {
-				builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_value(*self).unwrap()
+				builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_value(*self)
 			}
 
 			fn write_null<C: Context>(builder: &mut dyn ArrayBuilder, _context: C) {
-				builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_null().unwrap()
+				builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_null()
 			}
 
 			fn read(&mut self, array: ArrayRef, idx: usize) {
@@ -109,11 +109,11 @@ impl Arrow for bool {
 	}
 
 	fn write<C: Context>(&self, builder: &mut dyn ArrayBuilder, _context: C) {
-		builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_value(*self).unwrap()
+		builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_value(*self)
 	}
 
 	fn write_null<C: Context>(builder: &mut dyn ArrayBuilder, _context: C) {
-		builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_null().unwrap()
+		builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap().append_null()
 	}
 
 	fn read(&mut self, array: ArrayRef, idx: usize) {
@@ -212,12 +212,12 @@ impl<T> Arrow for Vec<T> where T: Arrow {
 		for x in self {
 			x.write(builder.values(), context);
 		}
-		builder.append(true).unwrap();
+		builder.append(true);
 	}
 
 	fn write_null<C: Context>(builder: &mut dyn ArrayBuilder, _context: C) {
 		let builder = builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap();
-		builder.append(false).unwrap();
+		builder.append(false);
 	}
 
 	fn read(&mut self, array: ArrayRef, idx: usize) {
@@ -275,7 +275,7 @@ impl<T, const N: usize> Arrow for [T; N] where T: Arrow {
 		for (i, x) in self.iter().enumerate() {
 			x.write(builder.field_builder::<T::Builder>(i).unwrap(), context);
 		}
-		builder.append(true).unwrap();
+		builder.append(true);
 	}
 
 	fn write_null<C: Context>(builder: &mut dyn ArrayBuilder, context: C) {
@@ -283,7 +283,7 @@ impl<T, const N: usize> Arrow for [T; N] where T: Arrow {
 		for i in 0 .. N {
 			T::write_null(builder.field_builder::<T::Builder>(i).unwrap(), context);
 		}
-		builder.append(false).unwrap();
+		builder.append(false);
 	}
 
 	fn read(&mut self, array: ArrayRef, idx: usize) {
@@ -323,12 +323,12 @@ impl<T, const N: usize> Arrow for [T; N] where T: Arrow {
 		for i in 0 .. N {
 			self[i].write(builder.values(), context);
 		}
-		builder.append(true).unwrap();
+		builder.append(true);
 	}
 
 	fn write_null<C: Context>(builder: &mut dyn ArrayBuilder, context: C) {
 		let builder = builder.as_any_mut().downcast_mut::<Self::Builder>().unwrap();
-		builder.append(false).unwrap();
+		builder.append(false);
 	}
 
 	fn read(&mut self, array: ArrayRef, idx: usize) {

--- a/peppi-derive/src/lib.rs
+++ b/peppi-derive/src/lib.rs
@@ -180,7 +180,6 @@ impl ToTokens for MyInputReceiver {
 					let num_fields = builder.num_fields();
 					#arrow_writers
 					builder.append(true)
-						.expect(stringify!(Failed to append for: #ident));
 				}
 
 				fn write_null<C: ::peppi_arrow::Context>(builder: &mut dyn ::arrow::array::ArrayBuilder, context: C) {
@@ -189,7 +188,6 @@ impl ToTokens for MyInputReceiver {
 					let num_fields = builder.num_fields();
 					#arrow_null_writers
 					builder.append(false)
-						.expect(stringify!(Failed to append null for: #ident));
 				}
 
 				fn read(&mut self, array: ::arrow::array::ArrayRef, idx: usize) {

--- a/peppi/Cargo.toml
+++ b/peppi/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/hohav/peppi"
 version = "1.0.0-alpha.6"
 
 [dependencies]
-arrow = "7.0"
+arrow = "20.0.0"
 byteorder = "1"
 chrono = { version = "0.4", features = ["serde"] }
 encoding_rs = "0.8"


### PR DESCRIPTION
Only breaking change: Changed builder `append` methods to be infallible where possible
https://github.com/apache/arrow-rs/pull/2103

Hoping to merge this to allow writing arrow data to memory without using the deprecated `InMemoryWriteableCursor`