### PR TITLE
Use Vec::resize instead of Vec::push to save on allocations

### DIFF
--- a/peppi/src/serde/collect.rs
+++ b/peppi/src/serde/collect.rs
@@ -184,8 +184,8 @@ where
 		_ => evt.id.array_index(),
 	};
 
-	while v.len() < idx {
-		v.push(None);
+	if v.len() < idx {
+		v.resize(idx, None);
 	}
 
 	if idx > v.len() {
@@ -203,9 +203,7 @@ where
 macro_rules! append_missing_frame_data {
 	( $arr: expr, $count: expr ) => {
 		for f in $arr.iter_mut() {
-			while f.len() < $count {
-				f.push(None);
-			}
+			f.resize($count, None)
 		}
 	};
 }
@@ -238,8 +236,8 @@ impl de::Handlers for Collector {
 			self.opts,
 		)?;
 		// reset items list in case of rollback
-		while self.items.len() <= idx {
-			self.items.push(Vec::new());
+		if self.items.len() <= idx {
+			self.items.resize(idx + 1, Vec::new());
 		}
 		if self.opts.rollback == Rollback::Last {
 			self.items[idx].clear();
@@ -331,9 +329,7 @@ impl de::Handlers for Collector {
 		append_missing_frame_data!(self.frames_followers.pre, frame_count);
 		append_missing_frame_data!(self.frames_followers.post, frame_count);
 
-		while self.items.len() < frame_count {
-			self.items.push(Vec::new());
-		}
+		self.items.resize(frame_count, Vec::new());
 
 		Ok(())
 	}


### PR DESCRIPTION
This is a small performance win we get from avoiding repeated `Vec` allocations. I attached some flamegraphs -- they are from my project repo, but you can ignore that part. I ran on ~1.8k replays as a test. If you download them to your computer and open in your browser you will get a better interactive version of the svg (idk why github's hosting removes that functionality). Ideally we'd have proper benchmarks... From my testing this provides a ~2.5% speedup.

Before:
![flamegraph-before](https://user-images.githubusercontent.com/10557166/187533572-963ebeea-2063-4bca-ad0d-bab838b64eb8.svg)

After:
![flamegraph-resize](https://user-images.githubusercontent.com/10557166/187533613-5157745b-7a80-4ab4-bfd8-1f11c9936ba9.svg)



