### PR TITLE
Add Platform enum for metadata

### DIFF
--- a/peppi/src/model/game.rs
+++ b/peppi/src/model/game.rs
@@ -278,16 +278,12 @@ pub struct GeckoCodes {
 /// Replay data for a single game of Melee.
 ///
 /// See https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md.
-#[derive(PartialEq, Serialize)]
+#[derive(PartialEq)]
 pub struct Game {
 	pub start: Start,
 	pub end: End,
 	pub frames: Frames,
-	#[serde(skip)]
 	pub metadata: metadata::Metadata,
-	#[serde(rename = "metadata")]
-	pub metadata_raw: serde_json::Map<String, serde_json::Value>,
-	#[serde(skip)] #[doc(hidden)]
 	pub gecko_codes: Option<GeckoCodes>,
 }
 

--- a/peppi/src/model/metadata.rs
+++ b/peppi/src/model/metadata.rs
@@ -39,6 +39,7 @@ pub struct Metadata {
 	pub platform: Option<Platform>,
 	pub console: Option<String>,
 	pub players: Option<Vec<Player>>,
+	pub raw: Map<String, Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -182,13 +183,14 @@ fn console(json: &Map<String, Value>) -> Result<Option<String>> {
 }
 
 impl Metadata {
-	pub fn parse(json: &Map<String, Value>) -> Result<Metadata> {
+	pub fn parse(json: Map<String, Value>) -> Result<Metadata> {
 		Ok(Metadata {
-			date: date(json)?,
-			duration: duration(json)?,
-			platform: platform(json)?,
-			players: players(json)?,
-			console: console(json)?,
+			date: date(&json)?,
+			duration: duration(&json)?,
+			platform: platform(&json)?,
+			players: players(&json)?,
+			console: console(&json)?,
+			raw: json,
 		})
 	}
 }

--- a/peppi/src/serde/collect.rs
+++ b/peppi/src/serde/collect.rs
@@ -82,7 +82,7 @@ macro_rules! into_game {
 		let ports: Vec<_> = start.players.iter().map(|p| p.port as usize).collect();
 
 		let metadata_raw = $gp.metadata.unwrap_or_default();
-		let metadata = Metadata::parse(&metadata_raw)?;
+		let metadata = Metadata::parse(metadata_raw)?;
 		if let Some(ref players) = metadata.players {
 			let meta_ports: Vec<_> = players.iter().map(|p| p.port as usize).collect();
 			if meta_ports != ports {
@@ -147,7 +147,6 @@ macro_rules! into_game {
 			end: end,
 			frames: Frames::$frames_type(frames),
 			metadata: metadata,
-			metadata_raw: metadata_raw,
 		}
 	}}
 }

--- a/peppi/src/serde/ser.rs
+++ b/peppi/src/serde/ser.rs
@@ -378,7 +378,7 @@ pub fn serialize<W: Write>(w: &mut W, game: &Game) -> Result<()> {
 
 	w.write_all(
 		&[0x55, 0x08, 0x6d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0x7b])?;
-	ubjson::ser::from_map(w, &game.metadata_raw)?;
+	ubjson::ser::from_map(w, &game.metadata.raw)?;
 	w.write_all(&[0x7d])?; // closing brace for `metadata`
 	w.write_all(&[0x7d])?; // closing brace for top-level map
 

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -15,7 +15,7 @@ use peppi::{
 		frame::{self, Buttons},
 		game::{DashBack, End, EndMethod, Frames, Game, Language, Netplay, Player, PlayerType, Scene, Start, ShieldDrop, Ucf},
 		item::Item,
-		metadata::{self, Metadata},
+		metadata::{self, Metadata, Platform},
 		primitives::{Direction, Port, Position, Velocity},
 		slippi::{Slippi, Version},
 	},
@@ -75,7 +75,7 @@ fn basic_game() -> Result<(), String> {
 	assert_eq!(game.metadata, Metadata {
 		date: "2018-06-22T07:52:59Z".parse::<DateTime<Utc>>().ok(),
 		duration: Some(5209),
-		platform: Some("dolphin".to_string()),
+		platform: Some(Platform::Dolphin),
 		players: Some(vec![
 			metadata::Player {
 				port: Port::P1,
@@ -348,7 +348,7 @@ fn joystick_udlr() -> Result<(), String> {
 #[test]
 fn nintendont() -> Result<(), String> {
 	let game = game("nintendont")?;
-	assert_eq!(game.metadata.platform, Some("nintendont".to_string()));
+	assert_eq!(game.metadata.platform, Some(Platform::Nintendont));
 	Ok(())
 }
 

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -15,7 +15,7 @@ use peppi::{
 		frame::{self, Buttons},
 		game::{DashBack, End, EndMethod, Frames, Game, Language, Netplay, Player, PlayerType, Scene, Start, ShieldDrop, Ucf},
 		item::Item,
-		metadata::{self, Metadata, Platform},
+		metadata::{self, Platform},
 		primitives::{Direction, Port, Position, Velocity},
 		slippi::{Slippi, Version},
 	},
@@ -72,32 +72,31 @@ fn slippi_old_version() -> Result<(), String> {
 fn basic_game() -> Result<(), String> {
 	let game = game("game")?;
 
-	assert_eq!(game.metadata, Metadata {
-		date: "2018-06-22T07:52:59Z".parse::<DateTime<Utc>>().ok(),
-		duration: Some(5209),
-		platform: Some(Platform::Dolphin),
-		players: Some(vec![
-			metadata::Player {
-				port: Port::P1,
-				characters: {
-					let mut m = HashMap::new();
-					m.insert(Internal::MARTH, 5209);
-					Some(m)
-				},
-				netplay: None,
+	let date = "2018-06-22T07:52:59Z".parse::<DateTime<Utc>>().ok();
+	let players = Some(vec![
+		metadata::Player {
+			port: Port::P1,
+			characters: {
+				let mut m = HashMap::new();
+				m.insert(Internal::MARTH, 5209);
+				Some(m)
 			},
-			metadata::Player {
-				port: Port::P2,
-				characters: {
-					let mut m = HashMap::new();
-					m.insert(Internal::FOX, 5209);
-					Some(m)
-				},
-				netplay: None,
+			netplay: None,
+		},
+		metadata::Player {
+			port: Port::P2,
+			characters: {
+				let mut m = HashMap::new();
+				m.insert(Internal::FOX, 5209);
+				Some(m)
 			},
-		]),
-		console: None,
-	});
+			netplay: None,
+		},
+	]);
+	assert_eq!(game.metadata.date, date);
+	assert_eq!(game.metadata.duration, Some(5209));
+	assert_eq!(game.metadata.platform, Some(Platform::Dolphin));
+	assert_eq!(game.metadata.players, players);
 
 	assert_eq!(game.start, Start {
 		slippi: Slippi { version: Version(1, 0, 0) },
@@ -535,7 +534,6 @@ fn round_trip() -> Result<(), String> {
 	assert_eq!(game1.start, game2.start);
 	assert_eq!(game1.end, game2.end);
 	assert_eq!(game1.metadata, game2.metadata);
-	assert_eq!(game1.metadata_raw, game2.metadata_raw);
 
 	match (game1.frames, game2.frames) {
 		(Frames::P2(f1), Frames::P2(f2)) => {


### PR DESCRIPTION
* Removes unused Serialize derives
* Creates `Platform` enum to represent possible platforms properly
* Moves `metadata_raw` into `Metadata.raw`

EDIT: I dropped the parts of this PR related to implementing serialization on metadata directly due to the concerns raised below. I don't think the issues are insurmountable, but it's probably a low-priority issue and/or is blocked by issues with the spec.