### PR TITLE
Add new handler trait with better abstraction

### DIFF
--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -116,11 +116,9 @@ pub fn parse<R: Read, H: serde::handlers::Handlers>(r: &mut R, handlers: &mut H,
 }
 
 /// Parse a Slippi replay from `r`, returning a `game::Game` object.
-pub fn game<R: Read>(r: &mut R, parse_opts: Option<&serde::de::Opts>, collect_opts: Option<&serde::collect::Opts>) -> Result<model::game::Game, ParseError> {
-	let mut game_parser = serde::collect::Collector {
-		opts: collect_opts.copied().unwrap_or_default(),
-		..Default::default()
-	};
-	parse(r, &mut game_parser, parse_opts)
-		.and_then(|_| game_parser.into_game().map_err(|e| ParseError { error: e, pos: None }))
+pub fn game<R: Read>(r: &mut R, parse_opts: Option<&serde::de::Opts>, rollback: serde::handlers::Rollback) -> Result<model::game::Game, ParseError> {
+	let collector = serde::collect::Collector::default();
+	let mut hook = serde::handlers::Hook::new(collector, rollback);
+	parse(r, &mut hook, parse_opts)
+		.and_then(|_| hook.into_inner().into_game().map_err(|e| ParseError { error: e, pos: None }))
 }

--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -55,6 +55,7 @@ pub mod model {
 pub mod serde {
 	pub mod arrow;
 	pub mod collect;
+	pub mod handlers;
 	pub mod de;
 	pub mod ser;
 }
@@ -105,7 +106,7 @@ impl<R: Read> Read for TrackingReader<R> {
 }
 
 /// Parse a Slippi replay from `r`, passing events to the callbacks in `handlers` as they occur.
-pub fn parse<R: Read, H: serde::de::Handlers>(r: &mut R, handlers: &mut H, opts: Option<&serde::de::Opts>) -> std::result::Result<(), ParseError> {
+pub fn parse<R: Read, H: serde::handlers::Handlers>(r: &mut R, handlers: &mut H, opts: Option<&serde::de::Opts>) -> std::result::Result<(), ParseError> {
 	let mut r = TrackingReader {
 		pos: 0,
 		reader: r,

--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -106,7 +106,7 @@ impl<R: Read> Read for TrackingReader<R> {
 }
 
 /// Parse a Slippi replay from `r`, passing events to the callbacks in `handlers` as they occur.
-pub fn parse<R: Read, H: serde::handlers::Handlers>(r: &mut R, handlers: &mut H, opts: Option<&serde::de::Opts>) -> std::result::Result<(), ParseError> {
+pub fn parse<R: Read, H: serde::handlers::EventHandler>(r: &mut R, handlers: &mut H, opts: Option<&serde::de::Opts>) -> std::result::Result<(), ParseError> {
 	let mut r = TrackingReader {
 		pos: 0,
 		reader: r,

--- a/peppi/src/model/game.rs
+++ b/peppi/src/model/game.rs
@@ -219,7 +219,7 @@ impl error::Error for UnexpectedPortCountError { }
 
 impl Frames {
 	/// Tries to downcast our inner value to a `Vec<Frame<N>>`.
-	pub fn downcast<const N: usize>(&self) -> Result<&Vec<Frame<N>>, UnexpectedPortCountError> {
+	pub fn downcast_ref<const N: usize>(&self) -> Result<&Vec<Frame<N>>, UnexpectedPortCountError> {
 		match self {
 			Self::P1(frames) => (frames as &dyn Any)
 				.downcast_ref::<Vec<Frame<N>>>()
@@ -232,6 +232,24 @@ impl Frames {
 				.ok_or(UnexpectedPortCountError {expected: N, actual: 3}),
 			Self::P4(frames) => (frames as &dyn Any)
 				.downcast_ref::<Vec<Frame<N>>>()
+				.ok_or(UnexpectedPortCountError {expected: N, actual: 4}),
+		}
+	}
+
+	/// Tries to downcast our inner value to a `Vec<Frame<N>>`.
+	pub fn downcast_mut<const N: usize>(&mut self) -> Result<&mut Vec<Frame<N>>, UnexpectedPortCountError> {
+		match self {
+			Self::P1(frames) => (frames as &mut dyn Any)
+				.downcast_mut::<Vec<Frame<N>>>()
+				.ok_or(UnexpectedPortCountError {expected: N, actual: 1}),
+			Self::P2(frames) => (frames as &mut dyn Any)
+				.downcast_mut::<Vec<Frame<N>>>()
+				.ok_or(UnexpectedPortCountError {expected: N, actual: 2}),
+			Self::P3(frames) => (frames as &mut dyn Any)
+				.downcast_mut::<Vec<Frame<N>>>()
+				.ok_or(UnexpectedPortCountError {expected: N, actual: 3}),
+			Self::P4(frames) => (frames as &mut dyn Any)
+				.downcast_mut::<Vec<Frame<N>>>()
 				.ok_or(UnexpectedPortCountError {expected: N, actual: 4}),
 		}
 	}

--- a/peppi/src/serde/collect.rs
+++ b/peppi/src/serde/collect.rs
@@ -4,290 +4,75 @@ use serde_json::{Map, Value};
 
 use crate::{
 	model::{
-		frame::{self, Frame, PortData},
-		game::{self, Frames, Game, GeckoCodes, NUM_PORTS},
-		item,
+		frame::Frame,
+		game::{self, Frames, Game, GeckoCodes},
 		metadata::Metadata,
-		primitives::Port,
 	},
-	serde::{
-		de::{FrameEvent, FrameId, Indexed, PortId},
-		handlers::Handlers,
-	}
+	serde::handlers::HandlersAbs,
 };
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum Rollback {
-	All, First, Last
-}
-
-impl Default for Rollback {
-	fn default() -> Self {
-		Self::All
-	}
-}
-
-impl TryFrom<&str> for Rollback {
-	type Error = String;
-	fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
-		match s {
-			"all" => Ok(Rollback::All),
-			"first" => Ok(Rollback::First),
-			"last" => Ok(Rollback::Last),
-			s => Err(format!("invalid Rollback: {}", s)),
-		}
-	}
-}
-
-impl From<Rollback> for &str {
-	fn from(r: Rollback) -> &'static str {
-		use Rollback::*;
-		match r {
-			All => "all",
-			First => "first",
-			Last => "last",
-		}
-	}
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-pub struct Opts {
-	pub rollback: Rollback,
-}
-
-#[derive(Debug, Default)]
-pub struct FrameEvents {
-	pub pre: [Vec<Option<frame::Pre>>; NUM_PORTS],
-	pub post: [Vec<Option<frame::Post>>; NUM_PORTS],
-}
 
 #[derive(Debug, Default)]
 pub struct Collector {
-	pub opts: Opts,
-	pub first_port: Option<Port>,
-
 	pub gecko_codes: Option<GeckoCodes>,
 	pub start: Option<game::Start>,
 	pub end: Option<game::End>,
-	pub frames_index: Vec<i32>,
-	pub frames_start: Vec<Option<frame::Start>>,
-	pub frames_end: Vec<Option<frame::End>>,
-	pub frames_leaders: FrameEvents,
-	pub frames_followers: FrameEvents,
-	pub items: Vec<Vec<item::Item>>,
+	pub frames: Option<Frames>,
 	pub metadata: Option<Map<String, Value>>,
-}
-
-macro_rules! into_game {
-	($gp: expr, $frames_type: ident => $( $idx: expr ),* $(,)? ) => {{
-		let start = $gp.start.ok_or_else(|| err!("missing start event"))?;
-		let end = $gp.end.ok_or_else(|| err!("missing end event"))?;
-		let ports: Vec<_> = start.players.iter().map(|p| p.port as usize).collect();
-
-		let metadata_raw = $gp.metadata.unwrap_or_default();
-		let metadata = Metadata::parse(&metadata_raw)?;
-		if let Some(ref players) = metadata.players {
-			let meta_ports: Vec<_> = players.iter().map(|p| p.port as usize).collect();
-			if meta_ports != ports {
-				return Err(err!("game-start ports ({:?}) != metadata ports ({:?})", ports, meta_ports));
-			}
-		}
-
-		let frame_count = $gp.frames_leaders.pre[ports[0]].len();
-
-		for p in &ports {
-			match $gp.frames_leaders.pre[*p].len() {
-				n if n == frame_count => (),
-				n => return Err(err!("mismatched pre-frame counts: {}: {}, {}", p, frame_count, n)),
-			}
-		}
-
-		for p in &ports {
-			match $gp.frames_leaders.post[*p].len() {
-				n if n == frame_count => (),
-				n => return Err(err!("mismatched post-frame counts: {}, {}", frame_count, n)),
-			}
-		}
-
-		let mut frames = Vec::with_capacity(frame_count);
-		for n in 0 .. frame_count {
-			frames.push(Frame {
-				index: match $gp.opts.rollback {
-					Rollback::All => $gp.frames_index[n],
-					_ => n as i32 + game::FIRST_FRAME_INDEX,
-				},
-				start: $gp.frames_start.get(n).copied().unwrap_or(None),
-				end: $gp.frames_end.get(n).copied().unwrap_or(None),
-				ports: [ $(
-					PortData {
-						leader: frame::Data {
-							pre: $gp.frames_leaders.pre[ports[$idx]][n]
-								.ok_or_else(|| err!("missing pre event: {}", n))?,
-							post: $gp.frames_leaders.post[ports[$idx]][n]
-								.ok_or_else(|| err!("missing post event: {}", n))?,
-						},
-						follower: {
-							let pre = $gp.frames_followers.pre[ports[$idx]].get(n).copied().unwrap_or(None);
-							let post = $gp.frames_followers.post[ports[$idx]].get(n).copied().unwrap_or(None);
-							match (pre, post) {
-								(Some(pre), Some(post)) => Some(Box::new(frame::Data {
-									pre: pre,
-									post: post,
-								})),
-								(None, None) => None,
-								_ => return Err(err!("inconsistent follower data (frame: {})", n)),
-							}
-						},
-					},
-				)* ],
-				items: $gp.items.get(n).cloned(),
-			});
-		}
-
-		Game {
-			gecko_codes: $gp.gecko_codes,
-			start: start,
-			end: end,
-			frames: Frames::$frames_type(frames),
-			metadata: metadata,
-			metadata_raw: metadata_raw,
-		}
-	}}
 }
 
 impl Collector {
 	pub fn into_game(self) -> Result<Game> {
-		match self.start {
-			None => Err(err!("missing start event")),
-			Some(ref start) => match start.players.len() {
-				1 => Ok(into_game!(self, P1 => 0)),
-				2 => Ok(into_game!(self, P2 => 0, 1)),
-				3 => Ok(into_game!(self, P3 => 0, 1, 2)),
-				4 => Ok(into_game!(self, P4 => 0, 1, 2, 3)),
-				n => Err(err!("unsupported number of ports: {}", n)),
-			},
-		}
+		let start = self.start.ok_or(err!("missing start event"))?;
+		let end = self.end.ok_or(err!("missing end event"))?;
+		let frames = self.frames.unwrap_or((match start.players.len() {
+			1 => Ok(Frames::P1(Vec::new())),
+			2 => Ok(Frames::P2(Vec::new())),
+			3 => Ok(Frames::P3(Vec::new())),
+			4 => Ok(Frames::P4(Vec::new())),
+			_ => Err(err!("invalid number of players")),
+		})?);
+		let metadata_raw = self.metadata.ok_or(err!("missing metadata event"))?;
+		let metadata = Metadata::parse(&metadata_raw)?;
+		Ok(Game {
+			start,
+			end,
+			frames,
+			metadata,
+			metadata_raw,
+			gecko_codes: self.gecko_codes,
+		})
 	}
 }
 
-fn append_frame_event<Id, Event>(v: &mut Vec<Option<Event>>, evt: FrameEvent<Id, Event>, frame_count: usize, opts: Opts) -> Result<usize> where Id: Indexed, Event: Copy {
-	let idx = match opts.rollback {
-		Rollback::All => frame_count - 1,
-		_ => evt.id.array_index(),
-	};
-
-	while v.len() < idx {
-		v.push(None);
+impl HandlersAbs for Collector {
+	fn gecko_codes(&mut self, codes: GeckoCodes) {
+					self.gecko_codes = Some(codes);
 	}
 
-	if idx > v.len() {
-		unreachable!();
-	} else if idx == v.len() {
-		v.push(Some(evt.event));
-	} else if opts.rollback == Rollback::Last {
-		v[idx] = Some(evt.event);
+	fn game_start(&mut self, s: game::Start) {
+		self.start = Some(s);
 	}
 
-	Ok(idx)
-}
-
-/// fills in missing frame data for eliminated players by duplicating their last-seen data
-macro_rules! append_missing_frame_data {
-	( $arr: expr, $count: expr ) => {
-		for f in $arr.iter_mut() {
-			while f.len() < $count {
-				f.push(None);
+	fn frame<const N: usize>(&mut self, f: Frame<N>) {
+		if matches!(self.frames, None) {
+			self.frames = match N {
+				1 => Some(Frames::P1(Vec::new())),
+				2 => Some(Frames::P2(Vec::new())),
+				3 => Some(Frames::P3(Vec::new())),
+				4 => Some(Frames::P4(Vec::new())),
+				_ => panic!(),
 			}
 		}
-	}
-}
-
-impl Handlers for Collector {
-	fn gecko_codes(&mut self, codes: &[u8], actual_size: u16) -> Result<()> {
-		self.gecko_codes = Some(GeckoCodes {
-			bytes: codes.to_vec(),
-			actual_size: actual_size,
-		});
-		Ok(())
-	}
-
-	fn game_start(&mut self, s: game::Start) -> Result<()> {
-		self.start = Some(s);
-		Ok(())
-	}
-
-	fn game_end(&mut self, s: game::End) -> Result<()> {
-		self.end = Some(s);
-		Ok(())
-	}
-
-	fn frame_start(&mut self, evt: FrameEvent<FrameId, frame::Start>) -> Result<()> {
-		self.frames_index.push(evt.id.index);
-		let idx = append_frame_event(&mut self.frames_start, evt, self.frames_index.len(), self.opts)?;
-		// reset items list in case of rollback
-		while self.items.len() <= idx {
-			self.items.push(Vec::new());
+		if let Some(frames) = &mut self.frames {
+			frames.downcast_mut::<N>().unwrap().push(f);
 		}
-		if self.opts.rollback == Rollback::Last {
-			self.items[idx].clear();
-		}
-		Ok(())
 	}
 
-	fn frame_pre(&mut self, evt: FrameEvent<PortId, frame::Pre>) -> Result<()> {
-		if self.first_port.is_none() {
-			self.first_port = Some(evt.id.port);
-		}
-		if self.frames_start.is_empty() && Some(evt.id.port) == self.first_port && !evt.id.is_follower {
-			self.frames_index.push(evt.id.index);
-		}
-		match evt.id.is_follower {
-			true => append_frame_event(&mut self.frames_followers.pre[evt.id.port as usize], evt, self.frames_index.len(), self.opts)?,
-			_ => append_frame_event(&mut self.frames_leaders.pre[evt.id.port as usize], evt, self.frames_index.len(), self.opts)?,
-		};
-		Ok(())
+	fn game_end(&mut self, e: game::End) {
+		self.end = Some(e);
 	}
 
-	fn frame_post(&mut self, evt: FrameEvent<PortId, frame::Post>) -> Result<()> {
-		match evt.id.is_follower {
-			true => append_frame_event(&mut self.frames_followers.post[evt.id.port as usize], evt, self.frames_index.len(), self.opts)?,
-			_ => append_frame_event(&mut self.frames_leaders.post[evt.id.port as usize], evt, self.frames_index.len(), self.opts)?,
-		};
-		Ok(())
-	}
-
-	fn frame_end(&mut self, evt: FrameEvent<FrameId, frame::End>) -> Result<()> {
-		append_frame_event(&mut self.frames_end, evt, self.frames_index.len(), self.opts)?;
-		Ok(())
-	}
-
-	fn item(&mut self, evt: FrameEvent<FrameId, item::Item>) -> Result<()> {
-		assert!(!self.items.is_empty());
-		let idx = match self.opts.rollback {
-			Rollback::All => self.items.len() - 1,
-			_ => evt.id.array_index(),
-		};
-		self.items[idx].push(evt.event);
-		Ok(())
-	}
-
-	fn metadata(&mut self, metadata: Map<String, Value>) -> Result<()> {
+	fn metadata(&mut self, metadata: Map<String, Value>) {
 		self.metadata = Some(metadata);
-		Ok(())
-	}
-
-	fn finalize(&mut self) -> Result<()> {
-		let frame_count = self.frames_leaders.pre.iter().map(Vec::len).max().unwrap_or(0);
-
-		append_missing_frame_data!(self.frames_leaders.pre, frame_count);
-		append_missing_frame_data!(self.frames_leaders.post, frame_count);
-		append_missing_frame_data!(self.frames_followers.pre, frame_count);
-		append_missing_frame_data!(self.frames_followers.post, frame_count);
-
-		while self.items.len() < frame_count {
-			self.items.push(Vec::new());
-		}
-
-		Ok(())
 	}
 }

--- a/peppi/src/serde/collect.rs
+++ b/peppi/src/serde/collect.rs
@@ -10,7 +10,10 @@ use crate::{
 		metadata::Metadata,
 		primitives::Port,
 	},
-	serde::de::{self, FrameEvent, FrameId, Indexed, PortId},
+	serde::{
+		de::{FrameEvent, FrameId, Indexed, PortId},
+		handlers::Handlers,
+	}
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -199,7 +202,7 @@ macro_rules! append_missing_frame_data {
 	}
 }
 
-impl de::Handlers for Collector {
+impl Handlers for Collector {
 	fn gecko_codes(&mut self, codes: &[u8], actual_size: u16) -> Result<()> {
 		self.gecko_codes = Some(GeckoCodes {
 			bytes: codes.to_vec(),

--- a/peppi/src/serde/collect.rs
+++ b/peppi/src/serde/collect.rs
@@ -8,7 +8,7 @@ use crate::{
 		game::{self, Frames, Game, GeckoCodes},
 		metadata::Metadata,
 	},
-	serde::handlers::HandlersAbs,
+	serde::handlers::GameHandler,
 };
 
 #[derive(Debug, Default)]
@@ -44,7 +44,7 @@ impl Collector {
 	}
 }
 
-impl HandlersAbs for Collector {
+impl GameHandler for Collector {
 	fn gecko_codes(&mut self, codes: GeckoCodes) {
 					self.gecko_codes = Some(codes);
 	}

--- a/peppi/src/serde/collect.rs
+++ b/peppi/src/serde/collect.rs
@@ -22,8 +22,8 @@ pub struct Collector {
 
 impl Collector {
 	pub fn into_game(self) -> Result<Game> {
-		let start = self.start.ok_or(err!("missing start event"))?;
-		let end = self.end.ok_or(err!("missing end event"))?;
+		let start = self.start.ok_or_else(|| err!("missing start event"))?;
+		let end = self.end.ok_or_else(|| err!("missing end event"))?;
 		let frames = self.frames.unwrap_or((match start.players.len() {
 			1 => Ok(Frames::P1(Vec::new())),
 			2 => Ok(Frames::P2(Vec::new())),
@@ -31,7 +31,7 @@ impl Collector {
 			4 => Ok(Frames::P4(Vec::new())),
 			_ => Err(err!("invalid number of players")),
 		})?);
-		let metadata_raw = self.metadata.ok_or(err!("missing metadata event"))?;
+		let metadata_raw = self.metadata.ok_or_else(|| err!("missing metadata event"))?;
 		let metadata = Metadata::parse(&metadata_raw)?;
 		Ok(Game {
 			start,

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -32,6 +32,7 @@ use crate::{
 		slippi,
 		triggers,
 	},
+	serde::handlers::Handlers,
 	ubjson,
 };
 
@@ -735,40 +736,6 @@ fn frame_post(r: &mut &[u8], last_char_states: &mut [CharState; NUM_PORTS]) -> R
 			animation_index,
 		},
 	})
-}
-
-/// Callbacks for events encountered while parsing a replay.
-///
-/// For frame events, there will be one event per frame per character
-/// (Ice Climbers are two characters).
-pub trait Handlers {
-	// Descriptions below partially copied from the Slippi spec:
-	// https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md
-
-	/// List of enabled Gecko codes. Currently unparsed.
-	fn gecko_codes(&mut self, _codes: &[u8], _actual_size: u16) -> Result<()> { Ok(()) }
-
-	/// How the game is set up; also includes the version of the extraction code.
-	fn game_start(&mut self, _: game::Start) -> Result<()> { Ok(()) }
-	/// The end of the game.
-	fn game_end(&mut self, _: game::End) -> Result<()> { Ok(()) }
-	/// Miscellaneous data not directly provided by Melee.
-	fn metadata(&mut self, _: serde_json::Map<String, serde_json::Value>) -> Result<()> { Ok(()) }
-
-	/// RNG seed and frame number at the start of a frame's processing.
-	fn frame_start(&mut self, _: FrameEvent<FrameId, frame::Start>) -> Result<()> { Ok(()) }
-	/// Pre-frame update, collected right before controller inputs are used to figure out the character's next action. Used to reconstruct a replay.
-	fn frame_pre(&mut self, _: FrameEvent<PortId, Pre>) -> Result<()> { Ok(()) }
-	/// Post-frame update, collected at the end of the Collision detection which is the last consideration of the game engine. Useful for making decisions about game states, such as computing stats.
-	fn frame_post(&mut self, _: FrameEvent<PortId, Post>) -> Result<()> { Ok(()) }
-	/// Indicates an entire frame's worth of data has been transferred/processed.
-	fn frame_end(&mut self, _: FrameEvent<FrameId, frame::End>) -> Result<()> { Ok(()) }
-
-	/// One event per frame per item, with a maximum of 15 updates per frame. Can be used for stats, training AIs, or visualization engines to handle items. Items include projectiles like lasers or needles.
-	fn item(&mut self, _: FrameEvent<FrameId, Item>) -> Result<()> { Ok(()) }
-
-	/// Called after all parse events have been handled.
-	fn finalize(&mut self) -> Result<()> { Ok(()) }
 }
 
 fn expect_bytes<R: Read>(r: &mut R, expected: &[u8]) -> Result<()> {

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -32,7 +32,7 @@ use crate::{
 		slippi,
 		triggers,
 	},
-	serde::handlers::Handlers,
+	serde::handlers::EventHandler,
 	ubjson,
 };
 
@@ -782,7 +782,7 @@ fn handle_splitter_event(buf: &[u8], accumulator: &mut Option<Vec<u8>>) -> Resul
 /// the parsed event.
 ///
 /// Returns the number of bytes read by this function.
-fn event<R: Read, H: Handlers, P: AsRef<Path>>(
+fn event<R: Read, H: EventHandler, P: AsRef<Path>>(
 		mut r: R,
 		payload_sizes: &HashMap<u8, u16>,
 		last_char_states: &mut LastCharStates,
@@ -845,7 +845,7 @@ pub struct Opts {
 }
 
 /// Parses a Slippi replay from `r`, passing events to the callbacks in `handlers` as they occur.
-pub fn deserialize<R: Read, H: Handlers>(mut r: &mut R, handlers: &mut H, opts: Option<&Opts>) -> Result<()> {
+pub fn deserialize<R: Read, H: EventHandler>(mut r: &mut R, handlers: &mut H, opts: Option<&Opts>) -> Result<()> {
 	// For speed, assume the `raw` element comes first and handle it manually.
 	// The official JS parser does this too, so it should be reliable.
 	expect_bytes(&mut r, &crate::SLIPPI_FILE_SIGNATURE)?;

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -68,7 +68,7 @@ impl LastCharStates {
 			State::Sheik(action_state::Sheik::TRANSFORM_GROUND) |
 			State::Sheik(action_state::Sheik::TRANSFORM_AIR)
 				if last_char_state.age >= SHEIK_TRANSFORM_FRAME => Some(Internal::ZELDA),
-			_ => last_char_state.character.or(last_char_state.state.character()),
+			_ => last_char_state.character.or_else(|| last_char_state.state.character()),
 		}
 	}
 

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -207,7 +207,8 @@ impl<H> Hook<H> where H: HandlersAbs {
 			self.add_new_frame(index);
 
 			// publish frames that can no longer be rolled back
-			while self.frames.len() > LARGEST_ROLLBACK as usize {
+			// we keep one extra frame to restore port data from
+			while self.frames.len() > (LARGEST_ROLLBACK + 1) as usize {
 				let frame = self.frames.pop_front().unwrap();
 				self.publish_frame(frame)?;
 			}

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use crate::{
 	model::{
 		frame::{self, Frame, Pre, Post},
-		game,
+		game::{self, GeckoCodes},
 		item::Item,
 		metadata::Metadata,
 	},
@@ -62,7 +62,7 @@ pub trait HandlersAbs {
 	/// Miscellaneous data not directly provided by Melee.
 	fn metadata(&mut self, _: Metadata) { }
 	/// List of enabled Gecko codes. Currently unparsed.
-	//fn gecko_codes(&mut self, _codes: Result<&[u8]>, _actual_size: u16) -> Result<()> { Ok(()) }
+	fn gecko_codes(&mut self, _: GeckoCodes) { }
 	/// Called after all parse events have been handled.
 	fn finalize(&mut self) { }
 }
@@ -318,6 +318,13 @@ impl<H> Handlers for Hook<H> where H: HandlersAbs {
 			}
 			frame_state.items.as_mut().unwrap().push(evt.event);
 		}
+		Ok(())
+	}
+	fn gecko_codes(&mut self, codes: &[u8], actual_size: u16) -> Result<()> {
+		self.hook.gecko_codes(game::GeckoCodes {
+			bytes: codes.to_vec(),
+			actual_size,
+		});
 		Ok(())
 	}
 	fn finalize(&mut self) -> Result<()> {

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -11,8 +11,7 @@ use crate::{
 	serde::de::{FrameEvent, FrameId, PortId,},
 };
 
-/// The largest possible rollback size in frames. Used to determine when a
-/// frame is finalized for replays before v3.7.0
+/// The largest possible rollback size in frames
 pub const LARGEST_ROLLBACK: u8 = 7;
 
 /// When the major scene number in the game start event is set to this value
@@ -53,6 +52,7 @@ pub trait EventHandler {
 	fn finalize(&mut self) -> Result<()> { Ok(()) }
 }
 
+/// Callbacks for the main parts of each game
 pub trait GameHandler {
 	/// How the game is set up; also includes the version of the extraction code.
 	fn game_start(&mut self, _: game::Start) { }
@@ -62,9 +62,9 @@ pub trait GameHandler {
 	fn game_end(&mut self, _: game::End) { }
 	/// Miscellaneous data not directly provided by Melee.
 	fn metadata(&mut self, _: Map<String, Value>) { }
-	/// List of enabled Gecko codes. Currently unparsed.
+	/// Enabled Gecko codes. Currently unparsed.
 	fn gecko_codes(&mut self, _: GeckoCodes) { }
-	/// Called after all parse events have been handled.
+	/// Called after all game events have been handled.
 	fn finalize(&mut self) { }
 }
 
@@ -106,6 +106,7 @@ impl FrameState {
 	}
 }
 
+/// Takes ownership of a GameHandler and adapts it for use as an EventHandler
 pub struct Hook<H> where H: GameHandler {
 	hook: H,
 	rollback: Rollback,

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -233,7 +233,8 @@ impl<H> Hook<H> where H: HandlersAbs {
 		}
 
 		// Saftey: index should always be <= self.highest_frame
-		let idx = usize::try_from(self.highest_frame - index).unwrap();
+		let off = usize::try_from(self.highest_frame - index).unwrap();
+		let idx = self.frames.len() - off - 1;
 		let fs = self.frames.get_mut(idx).ok_or(err!("frame not in buffer"))?;
 		Ok(Some(fs))
 	}

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -112,6 +112,7 @@ pub struct Hook<H> where H: HandlersAbs {
 	highest_frame: i32,
 	ignore_frame: i32,
 	ports: Option<Vec<usize>>,
+	version: Version,
 }
 
 macro_rules! publish_frame {
@@ -158,6 +159,7 @@ impl<H> Hook<H> where H: HandlersAbs {
 			highest_frame: game::FIRST_FRAME_INDEX - 1,
 			ignore_frame: game::FIRST_FRAME_INDEX - 1,
 			ports: None,
+			version: Version(0, 1, 0),
 		}
 	}
 
@@ -224,6 +226,9 @@ impl<H> Hook<H> where H: HandlersAbs {
 
 	fn add_new_frame(&mut self, index: i32) {
 		let mut new_frame = FrameState::new(index);
+		if self.version >= Version(3, 0, 0) {
+			new_frame.items = Some(Vec::new());
+		}
 		if let Some(latest_frame) = self.frames.back() {
 			// TODO: rework to copy only when needed
 			new_frame.leader = latest_frame.leader.clone();
@@ -250,6 +255,7 @@ impl<H> Hook<H> where H: HandlersAbs {
 impl<H> Handlers for Hook<H> where H: HandlersAbs {
 	fn game_start(&mut self, start: game::Start) -> Result<()> {
 		self.ports = Some(start.players.iter().map(|p| p.port as usize).collect());
+		self.version = start.slippi.version;
 
 		self.hook.game_start(start);
 		Ok(())

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -236,7 +236,7 @@ impl<H> Hook<H> where H: GameHandler {
 		// Saftey: index should always be <= self.highest_frame
 		let off = usize::try_from(self.highest_frame - index).unwrap();
 		let idx = self.frames.len() - off - 1;
-		let fs = self.frames.get_mut(idx).ok_or(err!("frame not in buffer"))?;
+		let fs = self.frames.get_mut(idx).ok_or_else(|| err!("frame not in buffer"))?;
 		Ok(Some(fs))
 	}
 

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -99,7 +99,7 @@ pub struct Hook<H> where H: HandlersAbs {
 	ports: Option<Vec<usize>>,
 }
 
-macro_rules! into_frame {
+macro_rules! publish_frame {
 	($hook: ident, $fs: expr, $const_generic: expr => $( $idx: expr ),* $(,)?) => {{
 		let ports = $hook.ports.as_ref().unwrap();
 		let frame = Frame {
@@ -190,10 +190,10 @@ impl<H> Hook<H> where H: HandlersAbs {
 		match &self.ports {
 			None => return Err(err!("missing start event")),
 			Some(ports) => match ports.len() {
-				1 => into_frame!(self, frame, 1 => 0),
-				2 => into_frame!(self, frame, 2 => 0, 1),
-				3 => into_frame!(self, frame, 3 => 0, 1, 2),
-				4 => into_frame!(self, frame, 4 => 0, 1, 2, 3),
+				1 => publish_frame!(self, frame, 1 => 0),
+				2 => publish_frame!(self, frame, 2 => 0, 1),
+				3 => publish_frame!(self, frame, 3 => 0, 1, 2),
+				4 => publish_frame!(self, frame, 4 => 0, 1, 2, 3),
 				n => return Err(err!("unsupported number of ports: {}", n)),
 			}
 		}

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -318,15 +318,6 @@ impl<H> Handlers for Hook<H> where H: HandlersAbs {
 	fn frame_end(&mut self, evt: FrameEvent<FrameId, frame::End>) -> Result<()> {
 		if let Some(frame_state) = self.get_frame_state(evt.id.index)? {
 			frame_state.end = Some(evt.event);
-
-			// Uses latest finalized frame field (v3.7.0+) to publish
-			// TODO: potentially superfluous, disable if inefficient
-			if let Some(lff) = evt.event.latest_finalized_frame {
-				while matches!(self.frames.front(), Some(fs) if fs.index <= lff) {
-					let frame = self.frames.pop_front().unwrap();
-					self.publish_frame(frame)?;
-				}
-			}
 		}
 		Ok(())
 	}

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -1,0 +1,273 @@
+use std::io::Result;
+use std::collections::VecDeque;
+use crate::{
+	model::{
+		frame::{self, Frame, Pre, Post},
+		game,
+		item::Item,
+		metadata::Metadata,
+	},
+	serde::de::{FrameEvent, FrameId, PortId,},
+};
+
+/// The largest possible rollback size in frames. Used to determine when a
+/// frame is finalized for replays before v3.7.0
+pub const LARGEST_ROLLBACK: u8 = 7;
+
+/// When the major scene number in the game start event is set to this value
+/// it indicates an online game is played and will have rollbacks
+pub const NETPLAY_MAJOR_SCENE: u8 = 8;
+
+/// Callbacks for events encountered while parsing a replay.
+///
+/// For frame events, there will be one event per frame per character
+/// (Ice Climbers are two characters).
+pub trait Handlers {
+	// Descriptions below partially copied from the Slippi spec:
+	// https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md
+
+	/// List of enabled Gecko codes. Currently unparsed.
+	fn gecko_codes(&mut self, _codes: &[u8], _actual_size: u16) -> Result<()> { Ok(()) }
+
+	/// How the game is set up; also includes the version of the extraction code.
+	fn game_start(&mut self, _: game::Start) -> Result<()> { Ok(()) }
+	/// The end of the game.
+	fn game_end(&mut self, _: game::End) -> Result<()> { Ok(()) }
+	/// Miscellaneous data not directly provided by Melee.
+	fn metadata(&mut self, _: serde_json::Map<String, serde_json::Value>) -> Result<()> { Ok(()) }
+
+	/// RNG seed and frame number at the start of a frame's processing.
+	fn frame_start(&mut self, _: FrameEvent<FrameId, frame::Start>) -> Result<()> { Ok(()) }
+	/// Pre-frame update, collected right before controller inputs are used to figure out the character's next action. Used to reconstruct a replay.
+	fn frame_pre(&mut self, _: FrameEvent<PortId, Pre>) -> Result<()> { Ok(()) }
+	/// Post-frame update, collected at the end of the Collision detection which is the last consideration of the game engine. Useful for making decisions about game states, such as computing stats.
+	fn frame_post(&mut self, _: FrameEvent<PortId, Post>) -> Result<()> { Ok(()) }
+	/// Indicates an entire frame's worth of data has been transferred/processed.
+	fn frame_end(&mut self, _: FrameEvent<FrameId, frame::End>) -> Result<()> { Ok(()) }
+
+	/// One event per frame per item, with a maximum of 15 updates per frame. Can be used for stats, training AIs, or visualization engines to handle items. Items include projectiles like lasers or needles.
+	fn item(&mut self, _: FrameEvent<FrameId, Item>) -> Result<()> { Ok(()) }
+
+	/// Called after all parse events have been handled.
+	fn finalize(&mut self) -> Result<()> { Ok(()) }
+}
+
+pub trait HandlersAbs {
+	/// How the game is set up; also includes the version of the extraction code.
+	fn game_start(&mut self, _: game::Start) { }
+	/// Single frame of the game
+	fn frame<const N: usize>(&mut self, _: Frame<N>) { }
+	/// The end of the game.
+	fn game_end(&mut self, _: game::End) { }
+	/// Miscellaneous data not directly provided by Melee.
+	fn metadata(&mut self, _: Metadata) { }
+	/// List of enabled Gecko codes. Currently unparsed.
+	//fn gecko_codes(&mut self, _codes: Result<&[u8]>, _actual_size: u16) -> Result<()> { Ok(()) }
+	/// Called after all parse events have been handled.
+	fn finalize(&mut self) { }
+}
+
+#[derive(Clone, Debug, Default)]
+struct FrameEvents {
+	pre: [Option<frame::Pre>; game::NUM_PORTS],
+	post: [Option<frame::Post>; game::NUM_PORTS],
+}
+
+#[derive(Debug, Default)]
+struct FrameState {
+	index: i32,
+	start: Option<frame::Start>,
+	leader: FrameEvents,
+	follow: FrameEvents,
+	end: Option<frame::End>,
+	items: Option<Vec<Item>>,
+}
+
+impl FrameState {
+	fn new(index: i32) -> FrameState {
+		FrameState {
+			index,
+			..FrameState::default()
+		}
+	}
+}
+
+pub struct Hook<H> where H: HandlersAbs {
+	hook: H,
+	frames: VecDeque<FrameState>,
+	highest_frame: i32,
+	ports: Option<Vec<usize>>,
+}
+
+macro_rules! into_frame {
+	($hook: ident, $fs: expr, $const_generic: expr => $( $idx: expr ),* $(,)?) => {{
+		let ports = $hook.ports.as_ref().unwrap();
+		let frame = Frame {
+			index: $fs.index,
+			start: $fs.start,
+			end: $fs.end,
+			items: $fs.items,
+			ports: [$( frame::PortData {
+				leader: frame::Data {
+					pre: $fs.leader.pre[ports[$idx]].ok_or_else(||
+						err!("missing pre event: index {}, port {}", $fs.index, ports[$idx]))?,
+					post: $fs.leader.post[ports[$idx]].ok_or_else(||
+						err!("missing post event: index {}, port {}", $fs.index, ports[$idx]))?,
+				},
+				follower: {
+					let pre = $fs.follow.pre[ports[$idx]];
+					let post = $fs.follow.post[ports[$idx]];
+					match (pre, post) {
+						(Some(pre), Some(post)) => Some(Box::new(frame::Data {
+							pre: pre,
+							post: post,
+						})),
+						(None, None) => None,
+						_ => return Err(err!("inconsistent follower data (frame: {})", $fs.index)),
+					}
+				},
+			}),*],
+		};
+
+		$hook.hook.frame(frame);
+	}}
+}
+
+impl<H> Hook<H> where H: HandlersAbs {
+	pub fn new(hook: H) -> Self {
+		let frames = VecDeque::new();
+		Self {
+			hook,
+			frames,
+			highest_frame: game::FIRST_FRAME_INDEX - 1,
+			ports: None,
+		}
+	}
+
+	fn get_frame_state(&mut self, index: i32) -> Result<&mut FrameState> {
+		if index > self.highest_frame + 1 {
+			// Frame skipped forward which shouldn't happen
+			return Err(err!("replay skips frame {:?}", self.highest_frame + 1));
+		} else if index == self.highest_frame + 1 {
+			// New frame seen
+			self.highest_frame += 1;
+			self.add_new_frame(index);
+
+			// publish frames that can no longer be rolled back
+			while self.frames.len() > LARGEST_ROLLBACK as usize {
+				let frame = self.frames.pop_front().unwrap();
+				self.publish_frame(frame)?;
+			}
+		} else if index < self.highest_frame {
+			// Rollback encountered
+			if index < self.highest_frame - LARGEST_ROLLBACK as i32 {
+				return Err(err!("rollback size too large"));
+			}
+
+			// All later frames are no longer valid
+			self.highest_frame = index;
+			while matches!(self.frames.back(), Some(fs) if fs.index >= index) {
+				self.frames.pop_back();
+			}
+			self.add_new_frame(index);
+		}
+
+		// Saftey: index should always be <= self.highest_frame
+		let idx = usize::try_from(self.highest_frame - index).unwrap();
+		self.frames.get_mut(idx).ok_or(err!("frame not in buffer"))
+	}
+
+	fn add_new_frame(&mut self, index: i32) {
+		let mut new_frame = FrameState::new(index);
+		if let Some(latest_frame) = self.frames.back() {
+			new_frame.leader = latest_frame.leader.clone();
+			new_frame.follow = latest_frame.follow.clone();
+		}
+		self.frames.push_back(new_frame);
+	}
+
+	fn publish_frame(&mut self, frame: FrameState) -> Result<()> {
+		match &self.ports {
+			None => return Err(err!("missing start event")),
+			Some(ports) => match ports.len() {
+				1 => into_frame!(self, frame, 1 => 0),
+				2 => into_frame!(self, frame, 2 => 0, 1),
+				3 => into_frame!(self, frame, 3 => 0, 1, 2),
+				4 => into_frame!(self, frame, 4 => 0, 1, 2, 3),
+				n => return Err(err!("unsupported number of ports: {}", n)),
+			}
+		}
+		Ok(())
+	}
+}
+
+impl<H> Handlers for Hook<H> where H: HandlersAbs {
+	fn game_start(&mut self, start: game::Start) -> Result<()> {
+		self.ports = Some(start.players.iter().map(|p| p.port as usize).collect());
+
+		self.hook.game_start(start);
+		Ok(())
+	}
+	fn game_end(&mut self, end: game::End) -> Result<()> {
+		while let Some(frame) = self.frames.pop_front() {
+			self.publish_frame(frame)?;
+		}
+		self.hook.game_end(end);
+		Ok(())
+	}
+	fn metadata(&mut self, metadata: serde_json::Map<String, serde_json::Value>) -> Result<()> {
+		let metadata = Metadata::parse(&metadata)?;
+		self.hook.metadata(metadata);
+		Ok(())
+	}
+
+	fn frame_start(&mut self, evt: FrameEvent<FrameId, frame::Start>) -> Result<()> {
+		let frame_state = self.get_frame_state(evt.id.index)?;
+		frame_state.start = Some(evt.event);
+		Ok(())
+	}
+	fn frame_pre(&mut self, evt: FrameEvent<PortId, Pre>) -> Result<()> {
+		let frame_state = self.get_frame_state(evt.id.index)?;
+		if evt.id.is_follower {
+			frame_state.follow.pre[evt.id.port as usize] = Some(evt.event);
+		} else {
+			frame_state.leader.pre[evt.id.port as usize] = Some(evt.event);
+		}
+		Ok(())
+	}
+	fn frame_post(&mut self, evt: FrameEvent<PortId, Post>) -> Result<()> {
+		let frame_state = self.get_frame_state(evt.id.index)?;
+		if evt.id.is_follower {
+			frame_state.follow.post[evt.id.port as usize] = Some(evt.event);
+		} else {
+			frame_state.leader.post[evt.id.port as usize] = Some(evt.event);
+		}
+		Ok(())
+	}
+	fn frame_end(&mut self, evt: FrameEvent<FrameId, frame::End>) -> Result<()> {
+		let frame_state = self.get_frame_state(evt.id.index)?;
+		frame_state.end = Some(evt.event);
+
+		// Uses latest finalized frame field (v3.7.0+) to publish
+		if let Some(lff) = evt.event.latest_finalized_frame {
+			while matches!(self.frames.front(), Some(fs) if fs.index <= lff) {
+				let frame = self.frames.pop_front().unwrap();
+				self.publish_frame(frame)?;
+			}
+		}
+		Ok(())
+	}
+	fn item(&mut self, evt: FrameEvent<FrameId, Item>) -> Result<()> {
+		let frame_state = self.get_frame_state(evt.id.index)?;
+
+		if frame_state.items == None {
+			frame_state.items = Some(Vec::new());
+		}
+		frame_state.items.as_mut().unwrap().push(evt.event);
+		Ok(())
+	}
+	fn finalize(&mut self) -> Result<()> {
+		self.hook.finalize();
+		Ok(())
+	}
+}

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -144,7 +144,11 @@ impl<H> Hook<H> where H: HandlersAbs {
 		}
 	}
 
-	fn get_frame_state(&mut self, index: i32) -> Result<&mut FrameState> {
+	pub fn into_inner(self) -> H {
+		self.hook
+	}
+
+	fn get_frame_state(&mut self, index: i32) -> Result<Option<&mut FrameState>> {
 		if index > self.highest_frame + 1 {
 			// Frame skipped forward which shouldn't happen
 			return Err(err!("replay skips frame {:?}", self.highest_frame + 1));

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -211,12 +211,10 @@ impl<H> Hook<H> where H: HandlersAbs {
 				let frame = self.frames.pop_front().unwrap();
 				self.publish_frame(frame)?;
 			}
+		} else if index <= self.ignore_frame {
+			return Ok(None);
 		} else if index < self.highest_frame {
-			if index == self.ignore_frame {
-				return Ok(None);
-			} else {
-				return Err(err!("Unexpected rollback without frame start"));
-			}
+			return Err(err!("Unexpected rollback without frame start"));
 		}
 
 		// Saftey: index should always be <= self.highest_frame

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -23,7 +23,7 @@ pub const NETPLAY_MAJOR_SCENE: u8 = 8;
 ///
 /// For frame events, there will be one event per frame per character
 /// (Ice Climbers are two characters).
-pub trait Handlers {
+pub trait EventHandler {
 	// Descriptions below partially copied from the Slippi spec:
 	// https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md
 
@@ -53,7 +53,7 @@ pub trait Handlers {
 	fn finalize(&mut self) -> Result<()> { Ok(()) }
 }
 
-pub trait HandlersAbs {
+pub trait GameHandler {
 	/// How the game is set up; also includes the version of the extraction code.
 	fn game_start(&mut self, _: game::Start) { }
 	/// Single frame of the game
@@ -106,7 +106,7 @@ impl FrameState {
 	}
 }
 
-pub struct Hook<H> where H: HandlersAbs {
+pub struct Hook<H> where H: GameHandler {
 	hook: H,
 	rollback: Rollback,
 	frames: VecDeque<FrameState>,
@@ -150,7 +150,7 @@ macro_rules! publish_frame {
 	}}
 }
 
-impl<H> Hook<H> where H: HandlersAbs {
+impl<H> Hook<H> where H: GameHandler {
 	pub fn new(hook: H, rollback: Rollback) -> Self {
 		let frames = VecDeque::new();
 		Self {
@@ -268,7 +268,7 @@ impl<H> Hook<H> where H: HandlersAbs {
 	}
 }
 
-impl<H> Handlers for Hook<H> where H: HandlersAbs {
+impl<H> EventHandler for Hook<H> where H: GameHandler {
 	fn game_start(&mut self, start: game::Start) -> Result<()> {
 		self.ports = Some(start.players.iter().map(|p| p.port as usize).collect());
 		self.version = start.slippi.version;

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -1,11 +1,12 @@
 use std::io::Result;
 use std::collections::VecDeque;
+use serde_json::{Map, Value};
 use crate::{
 	model::{
 		frame::{self, Frame, Pre, Post},
 		game::{self, GeckoCodes},
 		item::Item,
-		metadata::Metadata,
+		slippi::Version,
 	},
 	serde::de::{FrameEvent, FrameId, PortId,},
 };
@@ -60,7 +61,7 @@ pub trait HandlersAbs {
 	/// The end of the game.
 	fn game_end(&mut self, _: game::End) { }
 	/// Miscellaneous data not directly provided by Melee.
-	fn metadata(&mut self, _: Metadata) { }
+	fn metadata(&mut self, _: Map<String, Value>) { }
 	/// List of enabled Gecko codes. Currently unparsed.
 	fn gecko_codes(&mut self, _: GeckoCodes) { }
 	/// Called after all parse events have been handled.
@@ -268,11 +269,9 @@ impl<H> Handlers for Hook<H> where H: HandlersAbs {
 		Ok(())
 	}
 	fn metadata(&mut self, metadata: serde_json::Map<String, serde_json::Value>) -> Result<()> {
-		let metadata = Metadata::parse(&metadata)?;
 		self.hook.metadata(metadata);
 		Ok(())
 	}
-
 	fn frame_start(&mut self, evt: FrameEvent<FrameId, frame::Start>) -> Result<()> {
 		if evt.id.index <= self.highest_frame {
 			self.rollback(evt.id.index)?;

--- a/peppi/src/serde/handlers.rs
+++ b/peppi/src/serde/handlers.rs
@@ -267,6 +267,10 @@ impl<H> Handlers for Hook<H> where H: HandlersAbs {
 		Ok(())
 	}
 	fn finalize(&mut self) -> Result<()> {
+        // publish remaining frames here in case game_end never triggered
+		while let Some(frame) = self.frames.pop_front() {
+			self.publish_frame(frame)?;
+		}
 		self.hook.finalize();
 		Ok(())
 	}


### PR DESCRIPTION
The usability of event-based parsing is hindered by the `Handlers` trait functioning at the event-level. This means any implementer has to worry about rollbacks, frame data duplication after character elimination, and handling all sorts of errors. Right now this issue is blocking my progress on stats. I propose to rename `Handlers` to `EventHandler` and create a new trait `GameHandler`

```rust
pub trait GameHandler {
	fn game_start(&mut self, _: game::Start) { }
	fn frame<const N: usize>(&mut self, _: Frame<N>) { }
	fn game_end(&mut self, _: game::End) { }
	fn metadata(&mut self, _: Metadata) { }
	fn finalize(&mut self) { }
}
```

Also a struct `Hook` that wraps a `GameHandler` and handles all the events feeding the `GameHandler` as frames are finalized.

```rust
pub struct Hook<H> where H: GameHandler {
	hook: H,
	// ...
}

impl<H> EventHandler for Hook<H> where H: GameHandler { /* ... */ }
```

That way a user can parse with code like this:

```rust
struct DoWhatIWant;
impl GameHandler for DoWhatIWant {
	fn frame<const N: usize>(&mut self, frame: frame::Frame<N>) {
		println!("{:?}", frame);
	}
}

let mut buf = BufReader::new(File::open("game.slp").unwrap());
let mut hook = Hook::new(DoWhatIWant);
peppi::parse(&mut buf, &mut hook, None).unwrap();

```

This PR is a nearly finished. TODO:

* ~Add option for Rollback publishing. Right now it only publishes frames that are finalized (ie. can no longer be rolled back).~ DONE
* ~Re-implement Collector in terms of the new trait. We'd need to understand the performance impacts and this would be a good test for speed/correctness. If Collector can use the higher-level abstraction without performance problems, we could consider replacing the `Handlers` trait altogether~ DONE -- performance is unaffected or slightly improved
* ~Unify interface so that user only needs to care about implementing `GameHandler`. All things related to `Hook` and `EventHandler` can mostly be under the hood.~ DONE

Future work:
* Add a size hint function to `EventHandler`/`GameHandler` that hints the number of frames the game is expected to have in case it is known in advance (ie. read from a file). This would allow performance improvements with preallocation.
* Allow handler to indicate which parts of the game it cares about allowing the parser to scan past unneeded events (speculative idea)
* Support chaining/combining handlers -- kind of like https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.chain .
* Use some reference magic like https://docs.rs/replace_with/latest/replace_with/ to allow user to pass in reference to handler instead of an owned handler