### PR TITLE
Fix previous character state tracking during deserialization

### DIFF
--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -92,21 +92,31 @@ impl CharState {
 	}
 }
 
-// Technically the game can load any character as a follower, so we track them
-// too. The second half of the array holds data for the followers.
+// Technically melee can load any character as a follower, so we track them too
 #[derive(Debug, Default)]
-struct LastCharStates([CharState; 2 * NUM_PORTS]);
+struct LastCharStates {
+	leaders: [CharState; NUM_PORTS],
+	followers: [CharState; NUM_PORTS],
+}
 
 impl Index<PortId> for LastCharStates {
 	type Output = CharState;
 	fn index(&self, id: PortId) -> &Self::Output {
-		&self.0[id.port as usize + if id.is_follower { NUM_PORTS } else { 0 }]
+		if id.is_follower {
+			&self.followers[id.port as usize]
+		} else {
+			&self.leaders[id.port as usize]
+		}
 	}
 }
 
 impl IndexMut<PortId> for LastCharStates {
 	fn index_mut(&mut self, id: PortId) -> &mut Self::Output {
-		&mut self.0[id.port as usize + if id.is_follower { NUM_PORTS } else { 0 }]
+		if id.is_follower {
+			&mut self.followers[id.port as usize]
+		} else {
+			&mut self.leaders[id.port as usize]
+		}
 	}
 }
 

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -73,6 +73,11 @@ impl CharState {
 		const S_AIR: State = State::Sheik(action_state::Sheik::TRANSFORM_AIR);
 		const S_GROUND: State = State::Sheik(action_state::Sheik::TRANSFORM_GROUND);
 
+		self.character = Some(character);
+		if character != Internal::SHEIK && character != Internal::ZELDA {
+			// Skip state tracking for characters who can't transform
+			return;
+		}
 		self.age = match (self.state, state) {
 			(s0, s1) if s0 == s1 => self.age + 1,
 			// `TRANSFORM_AIR` can transition into `TRANSFORM_GROUND`
@@ -87,7 +92,6 @@ impl CharState {
 			(S_AIR, S_GROUND) | (S_GROUND, S_AIR) => min(SHEIK_TRANSFORM_FRAME - 1, self.age + 1),
 			_ => 0,
 		};
-		self.character = Some(character);
 		self.state = state;
 	}
 }

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -549,6 +549,26 @@ fn zelda_sheik_transformation() {
 }
 
 #[test]
+fn pre_frame_character() {
+	let game = game("ics2");
+	match game.frames {
+		Frames::P2(frames) => {
+			for f in frames.iter().take(4000) {
+				if let Some(character) = f.ports[0].leader.pre.state.character() {
+					assert_eq!(character, Internal::POPO);
+				}
+				if let Some(follower) = f.ports[0].follower.as_ref() {
+					if let Some(character) = follower.pre.state.character() {
+						assert_eq!(character, Internal::NANA);
+					}
+				}
+			}
+		}
+		_ => panic!("wrong number of ports"),
+	};
+}
+
+#[test]
 fn items() {
 	let game = game("items");
 	match game.frames {


### PR DESCRIPTION
The new test I added fails on the master branch. This bug caused some very strange behavior. Basically, the follower's pre-frame update would overwrite the last character state for the port so that the pre-frame update of the leader on the next frame (on the same port) would have Nana as the character.

I fixed the bug and took the chance to refactor the code a bit.