### PR TITLE
Fix GnW rapid jab action states

### DIFF
--- a/peppi/src/model/enums/action_state.rs
+++ b/peppi/src/model/enums/action_state.rs
@@ -624,8 +624,8 @@ pseudo_enum!(Fox: u16 {
 
 pseudo_enum!(GameAndWatch: u16 {
 	341 => JAB,
-	342 => JAB_2,
-	343 => RAPID_JABS,
+	342 => RAPID_JABS_START,
+	343 => RAPID_JABS_LOOP,
 	344 => RAPID_JABS_END,
 	345 => DOWN_TILT,
 	346 => SIDE_SMASH,


### PR DESCRIPTION
GnW doesn't have a second jab. It's just a single jab into a looping jab that has 3 states.