### PR TITLE
Fix: Sum split sizes because payload size can be wrong

### DIFF
--- a/peppi/src/model/game.rs
+++ b/peppi/src/model/game.rs
@@ -314,7 +314,7 @@ impl Frames {
 #[derive(Debug, PartialEq, Eq)]
 pub struct GeckoCodes {
 	pub bytes: Vec<u8>,
-	pub actual_size: u16,
+	pub actual_size: u32,
 }
 
 /// Replay data for a single game of Melee.

--- a/peppi/src/serde/collect.rs
+++ b/peppi/src/serde/collect.rs
@@ -211,7 +211,7 @@ macro_rules! append_missing_frame_data {
 }
 
 impl de::Handlers for Collector {
-	fn gecko_codes(&mut self, codes: &[u8], actual_size: u16) -> Result<()> {
+	fn gecko_codes(&mut self, codes: &[u8], actual_size: u32) -> Result<()> {
 		self.gecko_codes = Some(GeckoCodes {
 			bytes: codes.to_vec(),
 			actual_size: actual_size,

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -805,7 +805,7 @@ pub trait Handlers {
 	// https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md
 
 	/// List of enabled Gecko codes. Currently unparsed.
-	fn gecko_codes(&mut self, _codes: &[u8], _actual_size: u16) -> Result<()> {
+	fn gecko_codes(&mut self, _codes: &[u8], _actual_size: u32) -> Result<()> {
 		Ok(())
 	}
 
@@ -860,21 +860,23 @@ fn expect_bytes<R: Read>(r: &mut R, expected: &[u8]) -> Result<()> {
 	}
 }
 
-fn handle_splitter_event(buf: &[u8], accumulator: &mut Option<Vec<u8>>) -> Result<Option<u8>> {
+#[derive(Default)]
+struct SplitAccumulator {
+	raw: Vec<u8>,
+	actual_size: u32,
+}
+
+fn handle_splitter_event(buf: &[u8], accumulator: &mut SplitAccumulator) -> Result<Option<u8>> {
 	assert_eq!(buf.len(), 516);
 	let actual_size = (&buf[512..514]).read_u16::<BE>()?;
 	assert!(actual_size <= 512);
 	let wrapped_event = buf[514];
 	let is_final = buf[515] != 0;
 
-	if accumulator.is_none() {
-		*accumulator = Some(Vec::new());
-	}
-	let accumulator = accumulator.as_mut().unwrap();
-
 	// bytes beyond `actual_size` are meaningless,
 	// but save them anyway for lossless round-tripping
-	accumulator.extend_from_slice(&buf[0..512]);
+	accumulator.raw.extend_from_slice(&buf[0..512]);
+	accumulator.actual_size += actual_size as u32;
 
 	Ok(match is_final {
 		true => Some(wrapped_event),
@@ -892,7 +894,7 @@ fn event<R: Read, H: Handlers, P: AsRef<Path>>(
 	payload_sizes: &HashMap<u8, u16>,
 	last_char_states: &mut [CharState; NUM_PORTS],
 	handlers: &mut H,
-	splitter_accumulator: &mut Option<Vec<u8>>,
+	splitter_accumulator: &mut SplitAccumulator,
 	event_counts: &mut HashMap<u8, usize>,
 	debug_dir: Option<P>,
 ) -> Result<(usize, Option<Event>)> {
@@ -910,7 +912,7 @@ fn event<R: Read, H: Handlers, P: AsRef<Path>>(
 		if let Some(wrapped_event) = handle_splitter_event(&buf, splitter_accumulator)? {
 			code = wrapped_event;
 			buf.clear();
-			buf.append(splitter_accumulator.as_mut().unwrap());
+			buf.append(&mut splitter_accumulator.raw);
 		}
 	};
 
@@ -936,7 +938,7 @@ fn event<R: Read, H: Handlers, P: AsRef<Path>>(
 			FramePost => handlers.frame_post(frame_post(&mut &*buf, last_char_states)?)?,
 			FrameEnd => handlers.frame_end(frame_end(&mut &*buf)?)?,
 			Item => handlers.item(item(&mut &*buf)?)?,
-			GeckoCodes => handlers.gecko_codes(&buf, payload_sizes[&(GeckoCodes as u8)])?,
+			GeckoCodes => handlers.gecko_codes(&buf, splitter_accumulator.actual_size)?,
 		};
 	}
 
@@ -969,7 +971,7 @@ pub fn deserialize<R: Read, H: Handlers>(
 	let mut last_event: Option<Event> = None;
 	let skip_frames = opts.map(|o| o.skip_frames).unwrap_or(false);
 
-	let mut splitter_accumulator = None;
+	let mut splitter_accumulator = Default::default();
 
 	let debug_dir = opts.map(|o| o.debug_dir.as_ref()).unwrap_or(None);
 	// track how many of each event we've seen so we know where to put the debug output

--- a/peppi/src/serde/ser.rs
+++ b/peppi/src/serde/ser.rs
@@ -80,7 +80,8 @@ fn payload_sizes(game: &Game) -> Vec<(u8, u16)> {
 	}
 
 	if let Some(codes) = &game.gecko_codes {
-		sizes.push((Event::GeckoCodes as u8, codes.actual_size));
+		// Higher-order bits of actual_size are lost matching slippi-behavior
+		sizes.push((Event::GeckoCodes as u8, codes.actual_size as u16));
 	}
 
 	if ver.gte(3, 3) {


### PR DESCRIPTION
Newer replays load a large enough gecko code payload that the size overflows the `u16` within the payload sizes event. Therefore, we should not trust that number and instead sum the payload from each split event.

Some of the gecko codes and split event parsing code could use a refactor, but I think I will save that for a separate PR. Right now v3.13 support is blocked by this issue because in practice all v3.13 (and later) replays on dolphin have this size issue.