### PR TITLE
Improve round trip test

### DIFF
--- a/peppi/Cargo.toml
+++ b/peppi/Cargo.toml
@@ -20,9 +20,6 @@ pretty_assertions = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
-[dev-dependencies]
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
-
 [lib]
 name = "peppi"
 path = "src/lib.rs"

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -1,13 +1,12 @@
 use std::{
 	collections::HashMap,
 	fs::{self, File},
-	io::{BufReader, Read},
+	io::BufReader,
 	path::Path,
 };
 
 use chrono::{DateTime, Utc};
 use pretty_assertions::assert_eq;
-use xxhash_rust::xxh3::xxh3_64;
 
 use peppi::{
 	model::{
@@ -624,13 +623,6 @@ fn items() {
 	};
 }
 
-fn hash(path: impl AsRef<Path>) -> u64 {
-	let mut buf = Vec::new();
-	let mut f = File::open(path).unwrap();
-	f.read_to_end(&mut buf).unwrap();
-	xxh3_64(&buf)
-}
-
 fn frames<const N: usize>(f1: Vec<Frame<N>>, f2: Vec<Frame<N>>) {
 	assert_eq!(f1.len(), f2.len());
 	for idx in 0..f1.len() {
@@ -639,16 +631,22 @@ fn frames<const N: usize>(f1: Vec<Frame<N>>, f2: Vec<Frame<N>>) {
 }
 
 fn _round_trip(in_path: impl AsRef<Path> + Clone) {
-	let game1 = read_game(in_path.clone()).unwrap();
+	let in_bytes = fs::read(in_path.clone()).unwrap();
+	let game1 = peppi::game(&mut in_bytes.as_slice(), None, None).unwrap();
 	if game1.start.slippi.version > game::MAX_SUPPORTED_VERSION {
 		// Don't test serialization for replay versions we don't yet support
 		return;
 	}
-	let out_path = "/tmp/peppi_test_round_trip.slp";
-	let mut buf = File::create(out_path).unwrap();
-	serde::ser::serialize(&mut buf, &game1).unwrap();
-	let game2 = read_game(out_path).unwrap();
+	let mut out_bytes = Vec::with_capacity(in_bytes.len());
+	serde::ser::serialize(&mut out_bytes, &game1).unwrap();
 
+	// if we get a perfect byte-wise match we know we're correct. If not, we
+	// continue to detect where in the replay there is a difference.
+	if in_bytes == out_bytes {
+		return;
+	}
+
+	let game2 = peppi::game(&mut out_bytes.as_slice(), None, None).unwrap();
 	assert_eq!(game1.start, game2.start);
 	assert_eq!(game1.end, game2.end);
 	assert_eq!(game1.metadata, game2.metadata);
@@ -661,10 +659,6 @@ fn _round_trip(in_path: impl AsRef<Path> + Clone) {
 		(Frames::P4(f1), Frames::P4(f2)) => frames(f1, f2),
 		_ => panic!("wrong number of ports"),
 	}
-
-	assert_eq!(hash(in_path), hash(out_path));
-
-	fs::remove_file(out_path).unwrap();
 }
 
 #[test]

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -21,8 +21,8 @@ use peppi::{
 		},
 		frame::{self, Buttons, Frame},
 		game::{
-			DashBack, End, EndMethod, Frames, Game, Language, Netplay, Player, PlayerType, Scene,
-			ShieldDrop, Start, Ucf,
+			self, DashBack, End, EndMethod, Frames, Game, Language, Netplay, Player, PlayerType,
+			Scene, ShieldDrop, Start, Ucf,
 		},
 		item::Item,
 		metadata::{self, Metadata},
@@ -640,6 +640,10 @@ fn frames<const N: usize>(f1: Vec<Frame<N>>, f2: Vec<Frame<N>>) {
 
 fn _round_trip(in_path: impl AsRef<Path> + Clone) {
 	let game1 = read_game(in_path.clone()).unwrap();
+	if game1.start.slippi.version > game::MAX_SUPPORTED_VERSION {
+		// Don't test serialization for replay versions we don't yet support
+		return;
+	}
 	let out_path = "/tmp/peppi_test_round_trip.slp";
 	let mut buf = File::create(out_path).unwrap();
 	serde::ser::serialize(&mut buf, &game1).unwrap();


### PR DESCRIPTION
* Don't bother serializing versions we don't yet support
* Serialize replay to memory instead of disk saving a lot of time
* Remove redundant hash checking

The second two changes make the test suite run in ~3s instead of ~13s on my machine.