### PR TITLE
Resolve more clippy lints

### DIFF
--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -903,7 +903,7 @@ fn event<R: Read, H: Handlers, P: AsRef<Path>>(
 		.get(&code)
 		.ok_or_else(|| err!("unknown event: {}", code))? as usize;
 	let mut buf = vec![0; size];
-	r.read_exact(&mut *buf)?;
+	r.read_exact(&mut buf)?;
 
 	if code == 0x10 {
 		// message splitter
@@ -940,7 +940,7 @@ fn event<R: Read, H: Handlers, P: AsRef<Path>>(
 		};
 	}
 
-	Ok((1 + size as usize, event)) // +1 byte for the event code
+	Ok((size + 1, event)) // +1 byte for the event code
 }
 
 /// Options for parsing replays.

--- a/peppi/src/serde/ser.rs
+++ b/peppi/src/serde/ser.rs
@@ -99,7 +99,7 @@ fn gecko_codes<W: Write>(w: &mut W, codes: &GeckoCodes) -> Result<()> {
 		w.write_u16::<BE>(std::cmp::min(512, actual_size - pos) as u16)?;
 		w.write_u8(Event::GeckoCodes as u8)?;
 		pos += 512;
-		w.write_u8(if pos < actual_size { 0 } else { 1 })?;
+		w.write_u8(u8::from(pos >= actual_size))?;
 	}
 	Ok(())
 }


### PR DESCRIPTION
These all look good. I initially balked at using `u8::from` instead of the ternary statement that was there before, but it grew on me.