### PR TITLE
Implement `Default` trait for `Version`

### DIFF
--- a/peppi/src/model/slippi.rs
+++ b/peppi/src/model/slippi.rs
@@ -5,6 +5,12 @@ use serde::Serialize;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Version(pub u8, pub u8, pub u8);
 
+impl Default for Version {
+	fn default() -> Self {
+		Version(0, 1, 0)
+	}
+}
+
 impl Version {
 	pub fn gte(&self, major: u8, minor: u8) -> bool {
 		self.0 > major || (self.0 == major && self.1 >= minor)


### PR DESCRIPTION
Slippi replay base version is 0.1.0

A user might want to use `Version` to encode some sort of compatibility information in a type (eg. certain stats only work for certain replay versions). It's better to use `Default::default` than `Version(0,1,0)` because

1. You don't have to remember which version is the earliest
2. It more clearly communicates the intent to someone reading the code. For example, `min_version: Default::default()` more clearly communicates that all versions should work.
3. Allows user types that include a `Version` to also derive default if it makes sense