### PR TITLE
Impl read_exact for TrackingReader

### DIFF
--- a/peppi/src/lib.rs
+++ b/peppi/src/lib.rs
@@ -107,6 +107,11 @@ impl<R: Read> Read for TrackingReader<R> {
 		}
 		result
 	}
+	fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+		self.reader
+			.read_exact(buf)
+			.map(|_| self.pos += buf.len() as u64)
+	}
 }
 
 /// Parse a Slippi replay from `r`, passing events to the callbacks in `handlers` as they occur.


### PR DESCRIPTION
This allows the reader to utilize the specialized `read_exact` of the inner type instead of the default implementation. This provides a speedup of 10-20%.