### PR TITLE
Optimized Event-handler match arm order

### DIFF
--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -922,14 +922,15 @@ fn event<R: Read, H: Handlers, P: AsRef<Path>>(
 	if let Some(event) = event {
 		use Event::*;
 		match event {
-			GameStart => handlers.game_start(game_start(&mut &*buf)?)?,
-			GameEnd => handlers.game_end(game_end(&mut &*buf)?)?,
-			FrameStart => handlers.frame_start(frame_start(&mut &*buf)?)?,
 			FramePre => handlers.frame_pre(frame_pre(&mut &*buf, last_char_states)?)?,
 			FramePost => handlers.frame_post(frame_post(&mut &*buf, last_char_states)?)?,
+			FrameStart => handlers.frame_start(frame_start(&mut &*buf)?)?,
 			FrameEnd => handlers.frame_end(frame_end(&mut &*buf)?)?,
 			Item => handlers.item(item(&mut &*buf)?)?,
+			GameStart => handlers.game_start(game_start(&mut &*buf)?)?,
+			GameEnd => handlers.game_end(game_end(&mut &*buf)?)?,
 			GeckoCodes => handlers.gecko_codes(&buf, splitter_accumulator.actual_size)?,
+			
 		};
 	}
 

--- a/peppi/src/serde/de.rs
+++ b/peppi/src/serde/de.rs
@@ -930,7 +930,6 @@ fn event<R: Read, H: Handlers, P: AsRef<Path>>(
 			GameStart => handlers.game_start(game_start(&mut &*buf)?)?,
 			GameEnd => handlers.game_end(game_end(&mut &*buf)?)?,
 			GeckoCodes => handlers.gecko_codes(&buf, splitter_accumulator.actual_size)?,
-			
 		};
 	}
 


### PR DESCRIPTION
If rust pattern matching checks arms in the given order, this should be an easy way to save tens of thousands of comparisons per replay, hundreds of thousands for doubles/IC's. 

Eventually Rust should be getting something like the [[likely]]/[[unlikely]] decorators in c++ soon™, but until then manually reordering accomplishes the same thing.

Events are re-ordered by how often they occur per replay (per-character frame events > frame start/end > game start/end/gecko) and those are ordered by how long ago they were added to the file spec, since it's more likely that a replay will contain old features than new ones.

For a 2.5 minute (9,000 frames) 1v1 game, that should save 3 comparisons per frame for each player on pre and post frame events, which is 54,000 comparisons. If this is a 3.0.0+ replay, you're also saving 2 comparisons per frame on frame end events which is an additional 18,000 comparisons. Not much, but for a change this small it's kinda nice.
