### PR TITLE
Add tests for skip frames

### DIFF
--- a/peppi/tests/common/mod.rs
+++ b/peppi/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use peppi::model::game::Game;
+use peppi::serde::de;
 use peppi::ParseError;
 
 use std::{
@@ -7,9 +8,13 @@ use std::{
 	path::{Path, PathBuf},
 };
 
-pub fn read_game(path: impl AsRef<Path>) -> Result<Game, ParseError> {
+pub fn read_game(path: impl AsRef<Path>, skip_frames: bool) -> Result<Game, ParseError> {
 	let mut buf = BufReader::new(File::open(path).unwrap());
-	peppi::game(&mut buf, None, None)
+	let opts = de::Opts {
+		skip_frames,
+		..Default::default()
+	};
+	peppi::game(&mut buf, Some(&opts), None)
 }
 
 pub fn get_path(name: &str) -> PathBuf {
@@ -17,5 +22,5 @@ pub fn get_path(name: &str) -> PathBuf {
 }
 
 pub fn game(name: &str) -> Game {
-	read_game(get_path(name)).unwrap()
+	read_game(get_path(name), false).unwrap()
 }

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -202,6 +202,16 @@ fn basic_game() {
 }
 
 #[test]
+fn skip_frames() {
+	let game1 = game("game");
+	let game2 = read_game(get_path("game"), true).unwrap();
+	assert_eq!(game1.start, game2.start);
+	assert_eq!(game1.end, game2.end);
+	assert_eq!(game1.metadata, game2.metadata);
+	assert_eq!(game1.metadata_raw, game2.metadata_raw);
+}
+
+#[test]
 fn ics() {
 	let game = game("ics");
 	assert_eq!(
@@ -539,7 +549,8 @@ fn unknown_event() {
 
 #[test]
 fn corrupt_replay() {
-	assert!(matches!(read_game(get_path("corrupt")), Err(_)));
+	assert!(matches!(read_game(get_path("corrupt"), false), Err(_)));
+	assert!(matches!(read_game(get_path("corrupt"), true), Err(_)));
 }
 
 #[test]
@@ -639,11 +650,11 @@ fn frames<const N: usize>(f1: Vec<Frame<N>>, f2: Vec<Frame<N>>) {
 }
 
 fn _round_trip(in_path: impl AsRef<Path> + Clone) {
-	let game1 = read_game(in_path.clone()).unwrap();
+	let game1 = read_game(in_path.clone(), false).unwrap();
 	let out_path = "/tmp/peppi_test_round_trip.slp";
 	let mut buf = File::create(out_path).unwrap();
 	serde::ser::serialize(&mut buf, &game1).unwrap();
-	let game2 = read_game(out_path).unwrap();
+	let game2 = read_game(out_path, false).unwrap();
 
 	assert_eq!(game1.start, game2.start);
 	assert_eq!(game1.end, game2.end);

--- a/peppi/tests/peppi.rs
+++ b/peppi/tests/peppi.rs
@@ -209,6 +209,7 @@ fn skip_frames() {
 	assert_eq!(game1.end, game2.end);
 	assert_eq!(game1.metadata, game2.metadata);
 	assert_eq!(game1.metadata_raw, game2.metadata_raw);
+	assert_eq!(game2.frames, Frames::P2(Vec::new()));
 }
 
 #[test]


### PR DESCRIPTION
Seems like an oversight that this behavior isn't tested at all.