### PR TITLE
Error on multiple gecko list events.

### DIFF
--- a/src/io/slippi/de.rs
+++ b/src/io/slippi/de.rs
@@ -711,6 +711,11 @@ pub fn parse_event<R: Read>(mut r: R, state: &mut ParseState, opts: Option<&Opts
 			Payloads => return Err(err!("Duplicate payloads event")),
 			MessageSplitter => {}
 			GeckoCodes => {
+				if state.game.gecko_codes.is_some() {
+					return Err(err!(
+						"Multiple Gecko List events found. This is not supported."
+					));
+				}
 				state.game.gecko_codes = Some(game::GeckoCodes {
 					bytes: buf.to_vec(),
 					actual_size: state.split_accumulator.actual_size,

--- a/tests/peppi.rs
+++ b/tests/peppi.rs
@@ -774,6 +774,16 @@ fn corrupt_replay() {
 }
 
 #[test]
+fn multi_gecko_list() {
+	let err = read_game(get_path("multi_gecko_list"), false).unwrap_err();
+	assert!(
+		err.to_string().contains("Multiple Gecko List"),
+		"Expected error about multiple Gecko List events, got: {}",
+		err
+	);
+}
+
+#[test]
 fn zelda_sheik_transformation() {
 	let game = game("transform");
 	assert_eq!(
@@ -895,7 +905,7 @@ fn round_trip() {
 		.into_iter()
 		.map(|e| e.unwrap())
 		.filter(|e| match e.file_name().to_str().unwrap() {
-			"unknown_event.slp" | "corrupt.slp" => false,
+			"unknown_event.slp" | "corrupt.slp" | "multi_gecko_list.slp" => false,
 			_ => true,
 		}) {
 		println!("{:?}", entry.file_name());


### PR DESCRIPTION
Some games (typically those which result from spectating) have multiple gecko code events which would cause peppi to crash.