### PR TITLE
Allow stage events for 3.17.0 replays

### DIFF
--- a/gen/resources/preamble/immutable/mod.rs
+++ b/gen/resources/preamble/immutable/mod.rs
@@ -21,7 +21,7 @@ use arrow2::{
 };
 
 use crate::{
-	io::slippi::Version,
+	io::slippi::{Version, STAGE_EVENTS_VERSION},
 	frame::{self, mutable, transpose, Rollbacks},
 	game::Port,
 };
@@ -129,19 +129,19 @@ impl Frame {
 					.map(|i| self.item.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			fod_platforms: version.gte(3, 18).then(|| {
+			fod_platforms: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.fod_platform_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.fod_platform.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			dreamland_whispys: version.gte(3, 18).then(|| {
+			dreamland_whispys: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.dreamland_whispy_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.dreamland_whispy.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			stadium_transformations: version.gte(3, 18).then(|| {
+			stadium_transformations: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.stadium_transformation_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.stadium_transformation.as_ref().unwrap().transpose_one(i, version))

--- a/gen/resources/preamble/immutable/peppi.rs
+++ b/gen/resources/preamble/immutable/peppi.rs
@@ -166,7 +166,7 @@ impl Frame {
 			if version.gte(3, 0) {
 				fields.push(Field::new("end", End::data_type(version).clone(), false));
 				fields.push(Field::new("item", Self::item_data_type(version).clone(), false));
-				if version.gte(3, 18) {
+				if version.gte(3, 17) {
 					fields.push(Field::new("fod_platform", Self::fod_platform_data_type(version).clone(), false));
 					fields.push(Field::new("dreamland_whispy", Self::dreamland_whispy_data_type(version).clone(), false));
 					fields.push(Field::new("stadium_transformation", Self::stadium_transformation_data_type(version).clone(), false));
@@ -197,7 +197,7 @@ impl Frame {
 					item_values,
 					None,
 				).boxed());
-				if version.gte(3, 18) {
+				if version.gte(3, 17) {
 					let fod_platform_values = self.fod_platform.unwrap().into_struct_array(version).boxed();
 					arrays.push(ListArray::new(
 						Self::fod_platform_data_type(version),
@@ -267,7 +267,7 @@ impl Frame {
 			if version.gte(3, 0) {
 				assert_eq!("end", fields[3].name);
 				assert_eq!("item", fields[4].name);
-				if version.gte(3, 18) {
+				if version.gte(3, 17) {
 					assert_eq!("fod_platform", fields[5].name);
 					assert_eq!("dreamland_whispy", fields[6].name);
 					assert_eq!("stadium_transformation", fields[7].name);

--- a/gen/resources/preamble/immutable/peppi.rs
+++ b/gen/resources/preamble/immutable/peppi.rs
@@ -7,7 +7,7 @@ use arrow2::{
 };
 
 use crate::{
-	io::slippi::Version,
+	io::slippi::{Version, STAGE_EVENTS_VERSION},
 	frame::{
 		immutable::{Data, Frame, PortData},
 		PortOccupancy,
@@ -166,7 +166,7 @@ impl Frame {
 			if version.gte(3, 0) {
 				fields.push(Field::new("end", End::data_type(version).clone(), false));
 				fields.push(Field::new("item", Self::item_data_type(version).clone(), false));
-				if version.gte(3, 17) {
+				if version >= STAGE_EVENTS_VERSION {
 					fields.push(Field::new("fod_platform", Self::fod_platform_data_type(version).clone(), false));
 					fields.push(Field::new("dreamland_whispy", Self::dreamland_whispy_data_type(version).clone(), false));
 					fields.push(Field::new("stadium_transformation", Self::stadium_transformation_data_type(version).clone(), false));
@@ -197,7 +197,7 @@ impl Frame {
 					item_values,
 					None,
 				).boxed());
-				if version.gte(3, 17) {
+				if version >= STAGE_EVENTS_VERSION {
 					let fod_platform_values = self.fod_platform.unwrap().into_struct_array(version).boxed();
 					arrays.push(ListArray::new(
 						Self::fod_platform_data_type(version),
@@ -267,7 +267,7 @@ impl Frame {
 			if version.gte(3, 0) {
 				assert_eq!("end", fields[3].name);
 				assert_eq!("item", fields[4].name);
-				if version.gte(3, 17) {
+				if version >= STAGE_EVENTS_VERSION {
 					assert_eq!("fod_platform", fields[5].name);
 					assert_eq!("dreamland_whispy", fields[6].name);
 					assert_eq!("stadium_transformation", fields[7].name);

--- a/gen/resources/preamble/immutable/slippi.rs
+++ b/gen/resources/preamble/immutable/slippi.rs
@@ -12,7 +12,7 @@ use crate::{
 		immutable::{Data, Frame, PortData},
 		PortOccupancy,
 	},
-	io::slippi::{Version, de::Event},
+	io::slippi::{Version, STAGE_EVENTS_VERSION, de::Event},
 };
 
 type BE = byteorder::BigEndian;
@@ -148,7 +148,7 @@ impl Frame {
 			for port in &self.ports {
 				port.write_pre(w, version, idx, frame_id)?;
 			}
-			if version.gte(3, 18) {
+			if version >= STAGE_EVENTS_VERSION {
 				// FOD platform
 				let offset = self.fod_platform_offset.as_ref().unwrap();
 				for evt_idx in (offset[idx] as usize)..(offset[idx + 1] as usize) {

--- a/gen/resources/preamble/mutable.rs
+++ b/gen/resources/preamble/mutable.rs
@@ -15,7 +15,7 @@ use byteorder::ReadBytesExt;
 use std::io::Result;
 
 use crate::{
-	io::slippi::Version,
+	io::slippi::{Version, STAGE_EVENTS_VERSION},
 	frame::{transpose, PortOccupancy},
 	game::Port,
 };
@@ -130,12 +130,12 @@ impl Frame {
 			end: version.gte(3, 0).then(|| End::with_capacity(capacity, version)),
 			item: version.gte(3, 0).then(|| Item::with_capacity(0, version)),
 			item_offset: version.gte(3, 0).then(|| Offsets::<i32>::with_capacity(capacity)),
-			fod_platform: version.gte(3, 17).then(|| FodPlatform::with_capacity(0, version)),
-			fod_platform_offset: version.gte(3, 17).then(|| Offsets::<i32>::with_capacity(capacity)),
-			dreamland_whispy: version.gte(3, 17).then(|| DreamlandWhispy::with_capacity(0, version)),
-			dreamland_whispy_offset: version.gte(3, 17).then(|| Offsets::<i32>::with_capacity(capacity)),
-			stadium_transformation: version.gte(3, 17).then(|| StadiumTransformation::with_capacity(0, version)),
-			stadium_transformation_offset: version.gte(3, 17).then(|| Offsets::<i32>::with_capacity(capacity)),
+			fod_platform: (version >= STAGE_EVENTS_VERSION).then(|| FodPlatform::with_capacity(0, version)),
+			fod_platform_offset: (version >= STAGE_EVENTS_VERSION).then(|| Offsets::<i32>::with_capacity(capacity)),
+			dreamland_whispy: (version >= STAGE_EVENTS_VERSION).then(|| DreamlandWhispy::with_capacity(0, version)),
+			dreamland_whispy_offset: (version >= STAGE_EVENTS_VERSION).then(|| Offsets::<i32>::with_capacity(capacity)),
+			stadium_transformation: (version >= STAGE_EVENTS_VERSION).then(|| StadiumTransformation::with_capacity(0, version)),
+			stadium_transformation_offset: (version >= STAGE_EVENTS_VERSION).then(|| Offsets::<i32>::with_capacity(capacity)),
 		}
 	}
 
@@ -155,19 +155,19 @@ impl Frame {
 					.map(|i| self.item.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			fod_platforms: version.gte(3, 17).then(|| {
+			fod_platforms: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.fod_platform_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.fod_platform.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			dreamland_whispys: version.gte(3, 17).then(|| {
+			dreamland_whispys: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.dreamland_whispy_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.dreamland_whispy.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			stadium_transformations: version.gte(3, 17).then(|| {
+			stadium_transformations: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.stadium_transformation_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.stadium_transformation.as_ref().unwrap().transpose_one(i, version))

--- a/gen/resources/preamble/mutable.rs
+++ b/gen/resources/preamble/mutable.rs
@@ -130,12 +130,12 @@ impl Frame {
 			end: version.gte(3, 0).then(|| End::with_capacity(capacity, version)),
 			item: version.gte(3, 0).then(|| Item::with_capacity(0, version)),
 			item_offset: version.gte(3, 0).then(|| Offsets::<i32>::with_capacity(capacity)),
-			fod_platform: version.gte(3, 18).then(|| FodPlatform::with_capacity(0, version)),
-			fod_platform_offset: version.gte(3, 18).then(|| Offsets::<i32>::with_capacity(capacity)),
-			dreamland_whispy: version.gte(3, 18).then(|| DreamlandWhispy::with_capacity(0, version)),
-			dreamland_whispy_offset: version.gte(3, 18).then(|| Offsets::<i32>::with_capacity(capacity)),
-			stadium_transformation: version.gte(3, 18).then(|| StadiumTransformation::with_capacity(0, version)),
-			stadium_transformation_offset: version.gte(3, 18).then(|| Offsets::<i32>::with_capacity(capacity)),
+			fod_platform: version.gte(3, 17).then(|| FodPlatform::with_capacity(0, version)),
+			fod_platform_offset: version.gte(3, 17).then(|| Offsets::<i32>::with_capacity(capacity)),
+			dreamland_whispy: version.gte(3, 17).then(|| DreamlandWhispy::with_capacity(0, version)),
+			dreamland_whispy_offset: version.gte(3, 17).then(|| Offsets::<i32>::with_capacity(capacity)),
+			stadium_transformation: version.gte(3, 17).then(|| StadiumTransformation::with_capacity(0, version)),
+			stadium_transformation_offset: version.gte(3, 17).then(|| Offsets::<i32>::with_capacity(capacity)),
 		}
 	}
 
@@ -155,19 +155,19 @@ impl Frame {
 					.map(|i| self.item.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			fod_platforms: version.gte(3, 18).then(|| {
+			fod_platforms: version.gte(3, 17).then(|| {
 				let (start, end) = self.fod_platform_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.fod_platform.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			dreamland_whispys: version.gte(3, 18).then(|| {
+			dreamland_whispys: version.gte(3, 17).then(|| {
 				let (start, end) = self.dreamland_whispy_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.dreamland_whispy.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			stadium_transformations: version.gte(3, 18).then(|| {
+			stadium_transformations: version.gte(3, 17).then(|| {
 				let (start, end) = self.stadium_transformation_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| self.stadium_transformation.as_ref().unwrap().transpose_one(i, version))

--- a/src/frame/immutable/mod.rs
+++ b/src/frame/immutable/mod.rs
@@ -20,7 +20,7 @@ use arrow2::{array::PrimitiveArray, bitmap::Bitmap, buffer::Buffer, offset::Offs
 use crate::{
 	frame::{self, mutable, transpose, Rollbacks},
 	game::Port,
-	io::slippi::Version,
+	io::slippi::{Version, STAGE_EVENTS_VERSION},
 };
 
 /// Frame data for a single character (ICs are two characters).
@@ -130,7 +130,7 @@ impl Frame {
 					.map(|i| self.item.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			fod_platforms: version.gte(3, 18).then(|| {
+			fod_platforms: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.fod_platform_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| {
@@ -141,7 +141,7 @@ impl Frame {
 					})
 					.collect()
 			}),
-			dreamland_whispys: version.gte(3, 18).then(|| {
+			dreamland_whispys: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.dreamland_whispy_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| {
@@ -152,7 +152,7 @@ impl Frame {
 					})
 					.collect()
 			}),
-			stadium_transformations: version.gte(3, 18).then(|| {
+			stadium_transformations: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self
 					.stadium_transformation_offset
 					.as_ref()

--- a/src/frame/immutable/mod.rs
+++ b/src/frame/immutable/mod.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use arrow2::{array::PrimitiveArray, bitmap::Bitmap, buffer::Buffer, offset::OffsetsBuffer};
 
 use crate::{
-	frame::{self, Rollbacks, mutable, transpose},
+	frame::{self, mutable, transpose, Rollbacks},
 	game::Port,
 	io::slippi::Version,
 };

--- a/src/frame/immutable/mod.rs
+++ b/src/frame/immutable/mod.rs
@@ -18,9 +18,9 @@ use std::fmt;
 use arrow2::{array::PrimitiveArray, bitmap::Bitmap, buffer::Buffer, offset::OffsetsBuffer};
 
 use crate::{
-	frame::{self, mutable, transpose, Rollbacks},
+	frame::{self, Rollbacks, mutable, transpose},
 	game::Port,
-	io::slippi::{Version, STAGE_EVENTS_VERSION},
+	io::slippi::{STAGE_EVENTS_VERSION, Version},
 };
 
 /// Frame data for a single character (ICs are two characters).

--- a/src/frame/immutable/peppi.rs
+++ b/src/frame/immutable/peppi.rs
@@ -10,11 +10,11 @@ use arrow2::{
 
 use crate::{
 	frame::{
-		immutable::{Data, Frame, PortData},
 		PortOccupancy,
+		immutable::{Data, Frame, PortData},
 	},
-	game::{Port, NUM_PORTS},
-	io::slippi::{Version, STAGE_EVENTS_VERSION},
+	game::{NUM_PORTS, Port},
+	io::slippi::{STAGE_EVENTS_VERSION, Version},
 };
 
 trait StructArrayConvertible {

--- a/src/frame/immutable/peppi.rs
+++ b/src/frame/immutable/peppi.rs
@@ -10,10 +10,10 @@ use arrow2::{
 
 use crate::{
 	frame::{
-		PortOccupancy,
 		immutable::{Data, Frame, PortData},
+		PortOccupancy,
 	},
-	game::{NUM_PORTS, Port},
+	game::{Port, NUM_PORTS},
 	io::slippi::Version,
 };
 
@@ -178,7 +178,7 @@ impl Frame {
 					Self::item_data_type(version).clone(),
 					false,
 				));
-				if version.gte(3, 18) {
+				if version.gte(3, 17) {
 					fields.push(Field::new(
 						"fod_platform",
 						Self::fod_platform_data_type(version).clone(),
@@ -224,7 +224,7 @@ impl Frame {
 					)
 					.boxed(),
 				);
-				if version.gte(3, 18) {
+				if version.gte(3, 17) {
 					let fod_platform_values = self
 						.fod_platform
 						.unwrap()
@@ -320,7 +320,7 @@ impl Frame {
 			if version.gte(3, 0) {
 				assert_eq!("end", fields[3].name);
 				assert_eq!("item", fields[4].name);
-				if version.gte(3, 18) {
+				if version.gte(3, 17) {
 					assert_eq!("fod_platform", fields[5].name);
 					assert_eq!("dreamland_whispy", fields[6].name);
 					assert_eq!("stadium_transformation", fields[7].name);

--- a/src/frame/immutable/peppi.rs
+++ b/src/frame/immutable/peppi.rs
@@ -14,7 +14,7 @@ use crate::{
 		PortOccupancy,
 	},
 	game::{Port, NUM_PORTS},
-	io::slippi::Version,
+	io::slippi::{Version, STAGE_EVENTS_VERSION},
 };
 
 trait StructArrayConvertible {
@@ -178,7 +178,7 @@ impl Frame {
 					Self::item_data_type(version).clone(),
 					false,
 				));
-				if version.gte(3, 17) {
+				if version >= STAGE_EVENTS_VERSION {
 					fields.push(Field::new(
 						"fod_platform",
 						Self::fod_platform_data_type(version).clone(),
@@ -224,7 +224,7 @@ impl Frame {
 					)
 					.boxed(),
 				);
-				if version.gte(3, 17) {
+				if version >= STAGE_EVENTS_VERSION {
 					let fod_platform_values = self
 						.fod_platform
 						.unwrap()
@@ -320,7 +320,7 @@ impl Frame {
 			if version.gte(3, 0) {
 				assert_eq!("end", fields[3].name);
 				assert_eq!("item", fields[4].name);
-				if version.gte(3, 17) {
+				if version >= STAGE_EVENTS_VERSION {
 					assert_eq!("fod_platform", fields[5].name);
 					assert_eq!("dreamland_whispy", fields[6].name);
 					assert_eq!("stadium_transformation", fields[7].name);

--- a/src/frame/immutable/slippi.rs
+++ b/src/frame/immutable/slippi.rs
@@ -11,10 +11,10 @@ use byteorder::WriteBytesExt;
 
 use crate::{
 	frame::{
-		immutable::{Data, Frame, PortData},
 		PortOccupancy,
+		immutable::{Data, Frame, PortData},
 	},
-	io::slippi::{de::Event, Version, STAGE_EVENTS_VERSION},
+	io::slippi::{STAGE_EVENTS_VERSION, Version, de::Event},
 };
 
 type BE = byteorder::BigEndian;

--- a/src/frame/immutable/slippi.rs
+++ b/src/frame/immutable/slippi.rs
@@ -14,7 +14,7 @@ use crate::{
 		immutable::{Data, Frame, PortData},
 		PortOccupancy,
 	},
-	io::slippi::{de::Event, Version},
+	io::slippi::{de::Event, Version, STAGE_EVENTS_VERSION},
 };
 
 type BE = byteorder::BigEndian;
@@ -146,7 +146,7 @@ impl Frame {
 			for port in &self.ports {
 				port.write_pre(w, version, idx, frame_id)?;
 			}
-			if version.gte(3, 18) {
+			if version >= STAGE_EVENTS_VERSION {
 				// FOD platform
 				let offset = self.fod_platform_offset.as_ref().unwrap();
 				for evt_idx in (offset[idx] as usize)..(offset[idx + 1] as usize) {

--- a/src/frame/immutable/slippi.rs
+++ b/src/frame/immutable/slippi.rs
@@ -11,10 +11,10 @@ use byteorder::WriteBytesExt;
 
 use crate::{
 	frame::{
-		PortOccupancy,
 		immutable::{Data, Frame, PortData},
+		PortOccupancy,
 	},
-	io::slippi::{Version, de::Event},
+	io::slippi::{de::Event, Version},
 };
 
 type BE = byteorder::BigEndian;

--- a/src/frame/mutable.rs
+++ b/src/frame/mutable.rs
@@ -17,7 +17,7 @@ use byteorder::ReadBytesExt;
 use std::io::Result;
 
 use crate::{
-	frame::{PortOccupancy, transpose},
+	frame::{transpose, PortOccupancy},
 	game::Port,
 	io::slippi::Version,
 };
@@ -139,22 +139,22 @@ impl Frame {
 				.gte(3, 0)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
 			fod_platform: version
-				.gte(3, 18)
+				.gte(3, 17)
 				.then(|| FodPlatform::with_capacity(0, version)),
 			fod_platform_offset: version
-				.gte(3, 18)
+				.gte(3, 17)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
 			dreamland_whispy: version
-				.gte(3, 18)
+				.gte(3, 17)
 				.then(|| DreamlandWhispy::with_capacity(0, version)),
 			dreamland_whispy_offset: version
-				.gte(3, 18)
+				.gte(3, 17)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
 			stadium_transformation: version
-				.gte(3, 18)
+				.gte(3, 17)
 				.then(|| StadiumTransformation::with_capacity(0, version)),
 			stadium_transformation_offset: version
-				.gte(3, 18)
+				.gte(3, 17)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
 		}
 	}
@@ -183,7 +183,7 @@ impl Frame {
 					.map(|i| self.item.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			fod_platforms: version.gte(3, 18).then(|| {
+			fod_platforms: version.gte(3, 17).then(|| {
 				let (start, end) = self.fod_platform_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| {
@@ -194,7 +194,7 @@ impl Frame {
 					})
 					.collect()
 			}),
-			dreamland_whispys: version.gte(3, 18).then(|| {
+			dreamland_whispys: version.gte(3, 17).then(|| {
 				let (start, end) = self.dreamland_whispy_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| {
@@ -205,7 +205,7 @@ impl Frame {
 					})
 					.collect()
 			}),
-			stadium_transformations: version.gte(3, 18).then(|| {
+			stadium_transformations: version.gte(3, 17).then(|| {
 				let (start, end) = self
 					.stadium_transformation_offset
 					.as_ref()

--- a/src/frame/mutable.rs
+++ b/src/frame/mutable.rs
@@ -17,9 +17,9 @@ use byteorder::ReadBytesExt;
 use std::io::Result;
 
 use crate::{
-	frame::{transpose, PortOccupancy},
+	frame::{PortOccupancy, transpose},
 	game::Port,
-	io::slippi::{Version, STAGE_EVENTS_VERSION},
+	io::slippi::{STAGE_EVENTS_VERSION, Version},
 };
 
 type BE = byteorder::BigEndian;

--- a/src/frame/mutable.rs
+++ b/src/frame/mutable.rs
@@ -19,7 +19,7 @@ use std::io::Result;
 use crate::{
 	frame::{transpose, PortOccupancy},
 	game::Port,
-	io::slippi::Version,
+	io::slippi::{Version, STAGE_EVENTS_VERSION},
 };
 
 type BE = byteorder::BigEndian;
@@ -138,23 +138,17 @@ impl Frame {
 			item_offset: version
 				.gte(3, 0)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
-			fod_platform: version
-				.gte(3, 17)
+			fod_platform: (version >= STAGE_EVENTS_VERSION)
 				.then(|| FodPlatform::with_capacity(0, version)),
-			fod_platform_offset: version
-				.gte(3, 17)
+			fod_platform_offset: (version >= STAGE_EVENTS_VERSION)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
-			dreamland_whispy: version
-				.gte(3, 17)
+			dreamland_whispy: (version >= STAGE_EVENTS_VERSION)
 				.then(|| DreamlandWhispy::with_capacity(0, version)),
-			dreamland_whispy_offset: version
-				.gte(3, 17)
+			dreamland_whispy_offset: (version >= STAGE_EVENTS_VERSION)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
-			stadium_transformation: version
-				.gte(3, 17)
+			stadium_transformation: (version >= STAGE_EVENTS_VERSION)
 				.then(|| StadiumTransformation::with_capacity(0, version)),
-			stadium_transformation_offset: version
-				.gte(3, 17)
+			stadium_transformation_offset: (version >= STAGE_EVENTS_VERSION)
 				.then(|| Offsets::<i32>::with_capacity(capacity)),
 		}
 	}
@@ -183,7 +177,7 @@ impl Frame {
 					.map(|i| self.item.as_ref().unwrap().transpose_one(i, version))
 					.collect()
 			}),
-			fod_platforms: version.gte(3, 17).then(|| {
+			fod_platforms: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.fod_platform_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| {
@@ -194,7 +188,7 @@ impl Frame {
 					})
 					.collect()
 			}),
-			dreamland_whispys: version.gte(3, 17).then(|| {
+			dreamland_whispys: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self.dreamland_whispy_offset.as_ref().unwrap().start_end(i);
 				(start..end)
 					.map(|i| {
@@ -205,7 +199,7 @@ impl Frame {
 					})
 					.collect()
 			}),
-			stadium_transformations: version.gte(3, 17).then(|| {
+			stadium_transformations: (version >= STAGE_EVENTS_VERSION).then(|| {
 				let (start, end) = self
 					.stadium_transformation_offset
 					.as_ref()

--- a/src/io/slippi/de.rs
+++ b/src/io/slippi/de.rs
@@ -18,7 +18,11 @@ use crate::{
 		self, MAX_PLAYERS, Match, NUM_PORTS, Netplay, Player, PlayerType, Port, Quirks,
 		immutable::Game, port_occupancy, shift_jis::MeleeString,
 	},
-	io::{HashingReader, Result, expect_bytes, slippi::{self, STAGE_EVENTS_VERSION}, ubjson},
+	io::{
+		HashingReader, Result, expect_bytes,
+		slippi::{self, STAGE_EVENTS_VERSION},
+		ubjson,
+	},
 };
 
 type PayloadSizes = [Option<NonZeroU16>; 256];

--- a/src/io/slippi/de.rs
+++ b/src/io/slippi/de.rs
@@ -18,7 +18,7 @@ use crate::{
 		self, MAX_PLAYERS, Match, NUM_PORTS, Netplay, Player, PlayerType, Port, Quirks,
 		immutable::Game, port_occupancy, shift_jis::MeleeString,
 	},
-	io::{HashingReader, Result, expect_bytes, slippi, ubjson},
+	io::{HashingReader, Result, expect_bytes, slippi::{self, STAGE_EVENTS_VERSION}, ubjson},
 };
 
 type PayloadSizes = [Option<NonZeroU16>; 256];
@@ -817,7 +817,7 @@ pub fn parse_event<R: Read>(mut r: R, state: &mut ParseState, opts: Option<&Opts
 						.try_into()
 						.unwrap(),
 				);
-				if state.game.start.slippi.version.gte(3, 18) {
+				if state.game.start.slippi.version >= STAGE_EVENTS_VERSION {
 					push_offset::<u8>(
 						&mut state.game.frames.fod_platform_offset,
 						state

--- a/src/io/slippi/mod.rs
+++ b/src/io/slippi/mod.rs
@@ -16,6 +16,11 @@ pub use ser::write;
 /// This restriction may be removed in the future.
 pub const MAX_SUPPORTED_VERSION: Version = Version(3, 18, 0);
 
+/// Stage events (FoD platforms, Whispy, Stadium transformations) were officially added in
+/// 3.18.0, but Fizzi forgot to bump the version, so some 3.17.0 files also have them. For
+/// those that don't, the stage events arrays will be empty, which is fine.
+pub const STAGE_EVENTS_VERSION: Version = Version(3, 17, 0);
+
 /// Every `.slp` file starts with a UBJSON opening brace, "raw" key & type (`{U\x03raw[$U#l`).
 pub const FILE_SIGNATURE: [u8; 11] = [
 	0x7b, 0x55, 0x03, 0x72, 0x61, 0x77, 0x5b, 0x24, 0x55, 0x23, 0x6c,

--- a/src/io/slippi/ser.rs
+++ b/src/io/slippi/ser.rs
@@ -9,7 +9,7 @@ use crate::{
 	game::{self, GeckoCodes, MAX_PLAYERS, NUM_PORTS, Player, PlayerType, Port, immutable::Game},
 	io::{
 		Result,
-		slippi::{self, de::Event},
+		slippi::{self, STAGE_EVENTS_VERSION, de::Event},
 		ubjson,
 	},
 };
@@ -92,7 +92,7 @@ fn payload_sizes(game: &Game) -> PayloadSizes {
 						sizes.push(Event::GeckoCodes, codes.actual_size as u16 as usize);
 						sizes.push(Event::MessageSplitter, 516);
 					}
-					if ver.gte(3, 18) {
+					if ver >= STAGE_EVENTS_VERSION {
 						sizes.push(Event::FodPlatform, FRAME_NUMBER + FodPlatform::size(ver));
 						sizes.push(
 							Event::DreamlandWhispy,


### PR DESCRIPTION
The issue is that Fizzi forgot to bump the version to 3.18.0 initially, so some 3.17.0 replays have stage events. For those that do not, the stage events arrays will just be empty, which is fine.